### PR TITLE
Add Delta-DP mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ python main_text.py --dataset dataset_name
 ```
 Note that the text model requires the GloVe embedding file named 'glove.42B.300d.zip', which should be put in the main folder. The download link is [here](https://huggingface.co/stanfordnlp/glove/resolve/main/glove.42B.300d.zip).
 
+## Privacy option
+This repository includes an optional **Delta-DP** mechanism which applies central differential privacy on client updates. To enable it, specify a clipping norm and noise multiplier:
+
+```
+--clip_norm 1.0 --noise_multiplier 0.5 --dp_delta 1e-5
+```
+
+During training each client update is clipped to `clip_norm` and Gaussian noise with standard deviation `clip_norm * noise_multiplier` is added before aggregation. The scripts print a few values of each client's delta before and after noise as well as an approximate privacy `epsilon`.
+
+## Per-client transform layer
+Following the idea from [PrivateFL](https://github.com/BHui97/PrivateFL), each client can optionally own a small affine `TransformLayer`. It scales inputs by a learnable parameter $\alpha$ and shifts them by $\beta`. These parameters are initialized to 1 and 0 so the network starts as the identity mapping but can adapt through training. The layer is enabled by default and can be toggled via `--use_transform_layer 0`.
+
 ## Citation
 Welcome to cite our work! </br>
 

--- a/dp_utils.py
+++ b/dp_utils.py
@@ -1,0 +1,38 @@
+import math
+import torch
+
+
+def compute_noisy_delta(global_params, local_params, clip_norm, noise_mult):
+    """Compute clipped and noised updates for differential privacy."""
+    delta = {}
+    for k in global_params:
+        if not torch.is_floating_point(global_params[k]):
+            # integer buffers like num_batches_tracked are left unchanged
+            continue
+        delta[k] = local_params[k] - global_params[k]
+
+    if not delta:
+        return {}, {}
+
+    vec = torch.cat([v.view(-1) for v in delta.values()])
+    norm = torch.norm(vec)
+    scale = min(1.0, clip_norm / (norm + 1e-12))
+
+    for k in delta:
+        delta[k] = delta[k] * scale
+
+    delta_before_noise = {k: v.clone() for k, v in delta.items()}
+
+    if noise_mult > 0:
+        std = clip_norm * noise_mult
+        for k in delta:
+            delta[k] += torch.normal(0, std, size=delta[k].size(), device=delta[k].device)
+
+    return delta, delta_before_noise
+
+
+def compute_epsilon(num_steps, noise_mult, delta):
+    """Approximate (epsilon, delta)-DP for Gaussian mechanism."""
+    if noise_mult == 0:
+        return float('inf')
+    return math.sqrt(2 * num_steps * math.log(1 / delta)) / noise_mult

--- a/main_text.py
+++ b/main_text.py
@@ -17,6 +17,7 @@ from PIL import Image
 
 from model import *
 from utils import *
+from dp_utils import compute_noisy_delta, compute_epsilon
 import warnings
 
 warnings.filterwarnings('ignore')
@@ -183,6 +184,10 @@ def get_args():
     parser.add_argument('--save_model',type=int,default=0)
     parser.add_argument('--use_project_head', type=int, default=1)
     parser.add_argument('--server_momentum', type=float, default=0, help='the server momentum (FedAvgM)')
+    parser.add_argument('--use_transform_layer', type=int, default=1, help='toggle the per-client transform layer')
+    parser.add_argument('--clip_norm', type=float, default=1.0, help='max L2 norm for client update')
+    parser.add_argument('--noise_multiplier', type=float, default=0.0, help='noise multiplier for DP')
+    parser.add_argument('--dp_delta', type=float, default=1e-5, help='delta for DP accounting')
     args = parser.parse_args()
     return args
 
@@ -837,14 +842,24 @@ if __name__ == '__main__':
 
             local_train_net_few_shot(nets_this_round, args, net_dataidx_map, X_train, y_train, X_test, y_test, device=device)
 
-            for net_id, net in enumerate(nets_this_round.values()):
-                net_para = net.state_dict()
-                if net_id == 0:
-                    for key in net_para:
-                        global_w[key] = net_para[key] * fed_avg_freqs[net_id]
-                else:
-                    for key in net_para:
-                        global_w[key] += net_para[key] * fed_avg_freqs[net_id]
+            deltas = []
+            for nid, net in nets_this_round.items():
+                local_params = net.state_dict()
+                noisy_delta, delta_before = compute_noisy_delta(global_w, local_params, args.clip_norm, args.noise_multiplier)
+                sample_before = next(iter(delta_before.values())).view(-1)[:3].cpu()
+                sample_after = next(iter(noisy_delta.values())).view(-1)[:3].cpu()
+                print(f"Delta sample client {nid}: {sample_before.tolist()} -> {sample_after.tolist()}")
+                deltas.append(noisy_delta)
+            eps = compute_epsilon((round+1)*args.epochs, args.noise_multiplier, args.dp_delta)
+            print(f"Approx DP epsilon after {round+1} rounds: {eps:.4f}")
+
+            global_update = {k: torch.zeros_like(v) for k, v in global_w.items() if torch.is_floating_point(v)}
+            for idx, delta in enumerate(deltas):
+                for key in delta:
+                    global_update[key] += delta[key] * fed_avg_freqs[idx]
+
+            for key in global_update:
+                global_w[key] += global_update[key]
 
             if args.server_momentum:
                 delta_w = copy.deepcopy(global_w)


### PR DESCRIPTION
## Summary
- implement Delta-DP in `dp_utils.py`
- update training scripts with clipping and noisy aggregation
- document Delta-DP usage in the README
- fix Delta-DP handling for integer buffers
- introduce `TransformLayer` based on PrivateFL for per-client adaptation
- make transform layer optional via `--use_transform_layer`

## Testing
- `python -m py_compile main_image.py main_text.py dp_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6880c1f4df14832abdca612575fbe2da