### PR TITLE
Handle classifier params privately in DP

### DIFF
--- a/dp_utils.py
+++ b/dp_utils.py
@@ -5,12 +5,18 @@ import torch
 def compute_noisy_delta(global_params, local_params, clip_norm, noise_mult):
     """Compute clipped and noised updates for differential privacy.
 
-    Parameters whose names begin with ``"transform_layer."`` are skipped so that
-    personalized components are never aggregated or shared.
+    Parameters whose names begin with ``"transform_layer."`` or are equal to
+    ``"few_classify.weight"`` or ``"few_classify.bias"`` are skipped so that
+    personalized components and client-specific classifiers are never
+    aggregated or shared.
     """
     delta = {}
     for k in global_params:
-        if k.startswith("transform_layer."):
+        if (
+            k.startswith("transform_layer.")
+            or k == "few_classify.weight"
+            or k == "few_classify.bias"
+        ):
             continue
         if not torch.is_floating_point(global_params[k]):
             # integer buffers like num_batches_tracked are left unchanged

--- a/main_image.py
+++ b/main_image.py
@@ -925,7 +925,17 @@ if __name__ == '__main__':
             eps = compute_epsilon(dp_steps, args.noise_multiplier, args.dp_delta)
             print(f"Approx DP epsilon after {round+1} rounds: {eps:.4f}")
 
-            global_update = {k: torch.zeros_like(v) for k, v in global_w.items() if torch.is_floating_point(v) and not k.startswith("transform_layer.")}
+            # Aggregate only shared parameters; classifier weights stay private
+            global_update = {
+                k: torch.zeros_like(v)
+                for k, v in global_w.items()
+                if (
+                    torch.is_floating_point(v)
+                    and not k.startswith("transform_layer.")
+                    and k != "few_classify.weight"
+                    and k != "few_classify.bias"
+                )
+            }
             for nid, delta in deltas.items():
                 weight = fed_avg_freqs[nid]
                 for key in delta:

--- a/main_text.py
+++ b/main_text.py
@@ -886,7 +886,17 @@ if __name__ == '__main__':
             eps = compute_epsilon(dp_steps, args.noise_multiplier, args.dp_delta)
             print(f"Approx DP epsilon after {round+1} rounds: {eps:.4f}")
 
-            global_update = {k: torch.zeros_like(v) for k, v in global_w.items() if torch.is_floating_point(v) and not k.startswith("transform_layer.")}
+            # Aggregate only shared parameters; classifier weights stay private
+            global_update = {
+                k: torch.zeros_like(v)
+                for k, v in global_w.items()
+                if (
+                    torch.is_floating_point(v)
+                    and not k.startswith("transform_layer.")
+                    and k != "few_classify.weight"
+                    and k != "few_classify.bias"
+                )
+            }
 
             for nid, delta in deltas.items():
                 weight = fed_avg_freqs[nid]


### PR DESCRIPTION
## Summary
- skip `few_classify` params when forming deltas for DP
- avoid aggregating client-specific classifier weights in server update
- clarify comments about private classifier parameters

## Testing
- `python -m py_compile dp_utils.py main_image.py main_text.py`
- `find . -name '*.py' | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68836c3cf340832a804ad07f1407c6e5