### PR TITLE
Fix DP step count and switch to RDP accounting

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -921,8 +921,16 @@ if __name__ == '__main__':
                 sample_after = next(iter(noisy_delta.values())).view(-1)[:3].cpu()
                 print(f"Delta sample client {nid}: {sample_before.tolist()} -> {sample_after.tolist()}")
                 deltas[nid] = noisy_delta
-            dp_steps += len(nets_this_round) * args.epochs
-            eps = compute_epsilon(dp_steps, args.noise_multiplier, args.dp_delta)
+            # Each client's update is noised once per round, so count the number
+            # of participating clients rather than local epochs
+            dp_steps += len(nets_this_round)
+            eps = compute_epsilon(
+                dp_steps,
+                args.noise_multiplier,
+                args.dp_delta,
+                accountant="rdp",
+                sampling_rate=args.sample_fraction,
+            )
             print(f"Approx DP epsilon after {round+1} rounds: {eps:.4f}")
 
             # Aggregate only shared parameters; classifier weights stay private

--- a/main_text.py
+++ b/main_text.py
@@ -882,8 +882,15 @@ if __name__ == '__main__':
                 sample_after = next(iter(noisy_delta.values())).view(-1)[:3].cpu()
                 print(f"Delta sample client {nid}: {sample_before.tolist()} -> {sample_after.tolist()}")
                 deltas[nid] = noisy_delta
-            dp_steps += len(nets_this_round) * args.epochs
-            eps = compute_epsilon(dp_steps, args.noise_multiplier, args.dp_delta)
+            # Count each noisy aggregation once per round
+            dp_steps += len(nets_this_round)
+            eps = compute_epsilon(
+                dp_steps,
+                args.noise_multiplier,
+                args.dp_delta,
+                accountant="rdp",
+                sampling_rate=args.sample_fraction,
+            )
             print(f"Approx DP epsilon after {round+1} rounds: {eps:.4f}")
 
             # Aggregate only shared parameters; classifier weights stay private


### PR DESCRIPTION
## Summary
- count DP steps per round instead of per local epoch
- call `compute_epsilon` with RDP accountant and proper sampling rate

## Testing
- `python -m py_compile main_image.py main_text.py dp_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688731dce6c8832a98dd1d36b7baeba7