### PR TITLE
Preserve optimizer state across epochs

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -279,7 +279,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     elif args_optimizer == 'sgd':
         optimizer = optim.SGD(
             filter(lambda p: p.requires_grad, net.parameters()),
-            lr=0.05,
+            lr=lr,
             momentum=0.9,
             weight_decay=args.reg,
         )
@@ -311,23 +311,6 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                 N = args.N
                 K = 5#args.K
                 Q = args.Q
-            if args_optimizer == 'adam':
-                optimizer = optim.Adam(net.parameters(), lr=lr, weight_decay=args.reg)
-            elif args_optimizer == 'amsgrad':
-                optimizer = optim.Adam(
-                    filter(lambda p: p.requires_grad, net.parameters()),
-                    lr=lr,
-                    weight_decay=args.reg,
-                    amsgrad=True,
-                )
-            elif args_optimizer == 'sgd':
-                optimizer = optim.SGD(
-                    filter(lambda p: p.requires_grad, net.parameters()),
-                    lr=0.05,
-                    momentum=0.9,
-                    weight_decay=args.reg,
-                )
-
             net.train()
             optimizer.zero_grad()
             if args.dataset == 'FC100':

--- a/main_text.py
+++ b/main_text.py
@@ -268,7 +268,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     elif args_optimizer == 'sgd':
         optimizer = optim.SGD(
             filter(lambda p: p.requires_grad, net.parameters()),
-            lr=0.05,
+            lr=lr,
             momentum=0.9,
             weight_decay=args.reg,
         )
@@ -300,23 +300,6 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                 N = args.N
                 K = 5#args.K
                 Q = args.Q
-            if args_optimizer == 'adam':
-                optimizer = optim.Adam(net.parameters(), lr=lr, weight_decay=args.reg)
-            elif args_optimizer == 'amsgrad':
-                optimizer = optim.Adam(
-                    filter(lambda p: p.requires_grad, net.parameters()),
-                    lr=lr,
-                    weight_decay=args.reg,
-                    amsgrad=True,
-                )
-            elif args_optimizer == 'sgd':
-                optimizer = optim.SGD(
-                    filter(lambda p: p.requires_grad, net.parameters()),
-                    lr=0.05,
-                    momentum=0.9,
-                    weight_decay=args.reg,
-                )
-
             net.train()
             optimizer.zero_grad()
             if args.dataset == 'FC100':

--- a/tests/test_lr_scaling.py
+++ b/tests/test_lr_scaling.py
@@ -1,0 +1,21 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+# simple one-step training to check LR scaling
+x = torch.tensor([[1.0]])
+y = torch.tensor([[2.0]])
+loss_fn = nn.MSELoss()
+
+def run(lr):
+    m = nn.Linear(1,1,bias=False)
+    m.weight.data.fill_(1.0)
+    opt = optim.SGD(m.parameters(), lr=lr, momentum=0.9)
+    opt.zero_grad()
+    loss_fn(m(x), y).backward()
+    opt.step()
+    return m.weight.item()
+
+w1 = run(0.05)
+w2 = run(0.1)
+print("update_ratio", round((1-w1)/(1-w2), 3))


### PR DESCRIPTION
## Summary
- propagate `--lr` to SGD optimizers
- build optimizers once before `train_epoch`
- reuse the same optimizer inside `train_epoch`
- add a tiny test showing learning rate scaling

## Testing
- `python tests/test_lr_scaling.py`
- `python -m py_compile main_image.py main_text.py tests/test_lr_scaling.py`


------
https://chatgpt.com/codex/tasks/task_e_688881c284f0832a913b05706e19843e