### PR TITLE
Fix vocabulary indexing and rename embedding class

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ This is the code for the paper *Federated Few-shot Learning*, published in SIGKD
 
 ## Requirement:
 ```
-torch==1.11.0+cu113
-torchvision==0.12.0+cu113  
+torch==2.4.0
+torchvision==0.19.0
+torchtext==0.18.0
+numpy
+scikit-learn
+tqdm
+transformers
 ```
 
 

--- a/data/loader.py
+++ b/data/loader.py
@@ -321,7 +321,7 @@ def data_to_nparray(data, stoi, vocab_size, max_text_len=None):
         max_text_len = max(text_len)
 
     # initialize the big numpy array by <pad>
-    text = stoi['pad'] * np.ones([len(data), max_text_len],
+    text = stoi['<pad>'] * np.ones([len(data), max_text_len],
                                                dtype=np.int64)
     print('max_len', max_text_len)
 
@@ -330,7 +330,7 @@ def data_to_nparray(data, stoi, vocab_size, max_text_len=None):
     for i in range(len(data)):
 
         text[i, :len(data[i]['text'])] = [
-                stoi[x] if x in stoi else stoi['unk']
+                stoi[x] if x in stoi else stoi['<unk>']
                 for x in data[i]['text']]
         #text[i, :len(data[i]['text'])] = stoi(data[i]['text'])
 
@@ -438,12 +438,15 @@ def load_dataset(datadir, dataset, args=None):
     #vectors = Vectors('wiki.en.vec', cache='./')
     vectors=GloVe(name='42B', dim=300)
     print(vectors)
-    Vocab = vocab( collections.Counter(_read_words(all_data)),  # ,vectors=vectors,
-                  specials=['<pad>', '<unk>'],
-                  min_freq=5)
-    # Vocab.insert_token('<pad>',32135)
+    Vocab = vocab(
+        collections.Counter(_read_words(all_data)),
+        specials=['<pad>', '<unk>'],
+        min_freq=5,
+    )
     print('vocab size:', len(Vocab.get_stoi()))
-    Vocab.set_default_index(32137)
+    # use the index of <unk> token as default index
+    unk_index = Vocab.get_stoi()['<unk>']
+    Vocab.set_default_index(unk_index)
 
     print(len(vectors.stoi))
 
@@ -478,9 +481,9 @@ def load_dataset(datadir, dataset, args=None):
     else:
         max_text_len=44
 
-    train_data = data_to_nparray(train_data, vectors.stoi, wv_size[0], max_text_len=max_text_len)
-    val_data = data_to_nparray(val_data, vectors.stoi, wv_size[0], max_text_len=max_text_len)
-    test_data = data_to_nparray(test_data, vectors.stoi, wv_size[0], max_text_len=max_text_len)
+    train_data = data_to_nparray(train_data, Vocab.get_stoi(), wv_size[0], max_text_len=max_text_len)
+    val_data = data_to_nparray(val_data, Vocab.get_stoi(), wv_size[0], max_text_len=max_text_len)
+    test_data = data_to_nparray(test_data, Vocab.get_stoi(), wv_size[0], max_text_len=max_text_len)
 
     print(train_data['text'].shape)
 

--- a/main_image.py
+++ b/main_image.py
@@ -16,6 +16,7 @@ from sklearn import metrics
 from PIL import Image
 
 from model import *
+from model import WordEmbed
 from utils import *
 import warnings
 
@@ -230,12 +231,12 @@ def init_nets(net_configs, n_parties, args, device='cpu'):
         
     if args.mode=='few-shot' and args.method=='new':
         if args.dataset=='20newsgroup':
-            ebd=WORDEBD(args.finetune_ebd)
+            ebd=WordEmbed(args.finetune_ebd)
         for net_i in range(n_parties):
             if args.dataset=='FC100' or args.dataset=='miniImageNet':
                 net = ModelFed_Adp(args.model, args.out_dim, n_classes, total_classes, net_configs, args)
             else:
-                net = LSTMAtt(WORDEBD(args.finetune_ebd), args.out_dim, n_classes, total_classes,args)
+                net = LSTMAtt(WordEmbed(args.finetune_ebd), args.out_dim, n_classes, total_classes,args)
             if device == 'cpu':
                 net.to(device)
             else:

--- a/main_text.py
+++ b/main_text.py
@@ -16,6 +16,7 @@ from sklearn import metrics
 from PIL import Image
 
 from model import *
+from model import WordEmbed
 from utils import *
 import warnings
 
@@ -225,12 +226,12 @@ def init_nets(net_configs, n_parties, args, device='cpu'):
         
     if args.mode=='few-shot' and args.method=='new':
         if args.dataset=='20newsgroup':
-            ebd=WORDEBD(args.finetune_ebd)
+            ebd=WordEmbed(args.finetune_ebd)
         for net_i in range(n_parties):
             if args.dataset=='FC100' or args.dataset=='miniImageNet':
                 net = ModelFed_Adp(args.model, args.out_dim, n_classes, total_classes, net_configs, args)
             else:
-                net = LSTMAtt(WORDEBD(args.finetune_ebd), args.out_dim, n_classes, total_classes,args)
+                net = LSTMAtt(WordEmbed(args.finetune_ebd), args.out_dim, n_classes, total_classes,args)
             if device == 'cpu':
                 net.to(device)
             else:

--- a/model.py
+++ b/model.py
@@ -925,14 +925,14 @@ class ModelFed_Adp(nn.Module):
         return ebd, x, y
 
 
-class WORDEBD(nn.Module):
+class WordEmbed(nn.Module):
     '''
         An embedding layer that maps the token id into its corresponding word
         embeddings. The word embeddings are kept as fixed once initialized.
     '''
 
     def __init__(self, finetune_ebd):
-        super(WORDEBD, self).__init__()
+        super(WordEmbed, self).__init__()
         #vectors = Vectors('wiki.en.vec', cache='./')
         vectors = GloVe(name='42B', dim=300)
 
@@ -966,7 +966,7 @@ class LSTMAtt(nn.Module):
     def __init__(self, ebd, out_dim, n_classes, total_classes, args=None):
         super(LSTMAtt, self).__init__()
 
-        # ebd = WORDEBD(args.finetune_ebd)
+        # ebd = WordEmbed(args.finetune_ebd)
 
         self.args = args
         if args.dataset=='20newsgroup':

--- a/utils.py
+++ b/utils.py
@@ -281,10 +281,7 @@ def compute_accuracy(model, dataloader, get_confusion_matrix=False, device="cpu"
     true_labels_list, pred_labels_list = np.array([]), np.array([])
 
     correct, total = 0, 0
-    if device == 'cpu':
-        criterion = nn.CrossEntropyLoss()
-    elif "cuda" in device.type:
-        criterion = nn.CrossEntropyLoss().cuda()
+    criterion = nn.CrossEntropyLoss().to(device)
     loss_collector = []
     if multiloader:
         for loader in dataloader:
@@ -292,8 +289,7 @@ def compute_accuracy(model, dataloader, get_confusion_matrix=False, device="cpu"
                 for batch_idx, (x, target) in enumerate(loader):
                     # print("x:",x)
                     # print("target:",target)
-                    if device != 'cpu':
-                        x, target = x.cuda(), target.to(dtype=torch.int64).cuda()
+                    x, target = x.to(device), target.to(dtype=torch.int64, device=device)
                     _, _, out = model(x)
                     if len(target) == 1:
                         loss = criterion(out, target)
@@ -315,8 +311,7 @@ def compute_accuracy(model, dataloader, get_confusion_matrix=False, device="cpu"
         with torch.no_grad():
             for batch_idx, (x, target) in enumerate(dataloader):
                 # print("x:",x)
-                if device != 'cpu':
-                    x, target = x.cuda(), target.to(dtype=torch.int64).cuda()
+                x, target = x.to(device), target.to(dtype=torch.int64, device=device)
                 _, _, out = model(x)
                 loss = criterion(out, target)
                 _, pred_label = torch.max(out.data, 1)
@@ -349,15 +344,11 @@ def compute_loss(model, dataloader, device="cpu"):
     if model.training:
         model.eval()
         was_training = True
-    if device == 'cpu':
-        criterion = nn.CrossEntropyLoss()
-    elif "cuda" in device.type:
-        criterion = nn.CrossEntropyLoss().cuda()
+    criterion = nn.CrossEntropyLoss().to(device)
     loss_collector = []
     with torch.no_grad():
         for batch_idx, (x, target) in enumerate(dataloader):
-            if device != 'cpu':
-                x, target = x.cuda(), target.to(dtype=torch.int64).cuda()
+            x, target = x.to(device), target.to(dtype=torch.int64, device=device)
             _, _, out = model(x)
             loss = criterion(out, target)
             loss_collector.append(loss.item())


### PR DESCRIPTION
## Summary
- update PyTorch dependency versions
- use `<unk>` index when setting torchtext vocab default
- convert text tokens using the vocab indices
- rename `WORDEBD` in `model.py` to `WordEmbed`
- reference the renamed class from main scripts
- use `to(device)` when moving tensors in utility helpers

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889e8ec0f8c832a8e29c77cf7307bdb