### PR TITLE
Ensure per-client DP accounting in meta learning

### DIFF
--- a/main_text.py
+++ b/main_text.py
@@ -270,6 +270,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                               weight_decay=args.reg)
     loss_ce = nn.CrossEntropyLoss()
     loss_mse = nn.MSELoss()
+    client_sample_size = X_train_client.shape[0]
 
     def train_epoch(epoch, mode='train'):
 
@@ -335,9 +336,9 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         if test_only==True:
             K=test_only_k
 
-
-
-
+        support_batch = N * K
+        query_batch = N * Q
+        total_batch = support_batch + query_batch
 
         support_labels = torch.zeros(N * K, dtype=torch.long)
         for i in range(N):
@@ -475,6 +476,10 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     #                map(lambda p: p[1] - fine_tune_lr * p[0], zip(grad, net_para)))
                     # net_para={key:value for key, value in zip(net.state_dict().keys(),net.state_dict().values())}
                     net_new.load_state_dict(net_para)
+                    if accountant is not None:
+                        accountant.step(noise_multiplier=args.dp_noise,
+                                        sample_size=client_sample_size,
+                                        batch_size=support_batch)
 
                 X_out_query, _, out = net_new(X_total_query)
                 X_out_sup, X_transformer_out_sup, _ = net_new(X_total_sup)
@@ -499,7 +504,9 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                             grad.data.add_(noise)
                 optimizer.step()
                 if accountant is not None:
-                    accountant.step(noise_multiplier=args.dp_noise, sample_rate=sample_rate)
+                    accountant.step(noise_multiplier=args.dp_noise,
+                                    sample_size=client_sample_size,
+                                    batch_size=total_batch)
                 ############################
 
                 X_out_all, x_all, out_all = net(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
@@ -523,6 +530,10 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                         grad_ = grad_ + torch.randn_like(grad_) * args.dp_noise * args.dp_clip
                     net_para_ori[key]=net_para_ori[key]-args.meta_lr*grad_
                 net.load_state_dict(net_para_ori)
+                if accountant is not None:
+                    accountant.step(noise_multiplier=args.dp_noise,
+                                    sample_size=client_sample_size,
+                                    batch_size=query_batch)
                 ##################################
                 del net_new,X_out_query, out
 
@@ -751,9 +762,7 @@ if __name__ == '__main__':
     Q=args.Q
 
     accountant = None
-    sample_rate = None
     if args.use_dp:
-        sample_rate = min(1.0, N * (K + Q) / len(X_train))
         accountant = RDPAccountant()
 
     support_labels=torch.zeros(N*K,dtype=torch.long)


### PR DESCRIPTION
## Summary
- track each client's dataset size and per-update batch counts in `train_net_few_shot_new`
- call `accountant.step()` after every DP-noised inner loop and meta-gradient update for image and text modes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688c251ae854832aa91a35b934514fba