### PR TITLE
Apply global per-sample gradient clipping

### DIFF
--- a/main_text.py
+++ b/main_text.py
@@ -456,22 +456,37 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
                 for j in range(args.fine_tune_steps):
                     X_out_sup, X_transformer_out_sup, out = net_new(X_total_sup)
-                    loss = loss_ce(out, support_labels)
+                    losses = F.cross_entropy(out, support_labels, reduction='none')
 
                     net_para = net_new.state_dict()
                     param_require_grad = {}
                     for key, param in net_new.named_parameters():
                         if key == 'few_classify.weight' or key == 'few_classify.bias':
-                            # if key !='all_classify.weight' and key !='all_classify.bias':
                             if param.requires_grad:
                                 param_require_grad[key] = param
-                    grad = torch.autograd.grad(loss, param_require_grad.values(), allow_unused=True)
-                    for key, grad_ in zip(param_require_grad.keys(), grad):
-                        if grad_ == None: continue
-                        if args.use_dp:
-                            grad_ = grad_.clamp(-args.dp_clip, args.dp_clip)
-                            grad_ = grad_ + torch.randn_like(grad_) * args.dp_noise * args.dp_clip
-                        net_para[key] = net_para[key] - args.fine_tune_lr * grad_
+
+                    if args.use_dp:
+                        per_sample_grads = []
+                        for i in range(losses.size(0)):
+                            grad_i = torch.autograd.grad(losses[i], param_require_grad.values(), retain_graph=True, allow_unused=True)
+                            per_sample_grads.append(grad_i)
+                        per_param_grads = []
+                        params_list = list(param_require_grad.values())
+                        for idx in range(len(params_list)):
+                            grads = []
+                            for g in per_sample_grads:
+                                grads.append(g[idx] if g[idx] is not None else torch.zeros_like(params_list[idx]))
+                            per_param_grads.append(torch.stack(grads))
+                        dp_grads = dp_clip_and_noise(per_param_grads, args.dp_clip, args.dp_noise)
+                        for key, grad_ in zip(param_require_grad.keys(), dp_grads):
+                            net_para[key] = net_para[key] - args.fine_tune_lr * grad_
+                    else:
+                        loss = losses.mean()
+                        grad = torch.autograd.grad(loss, param_require_grad.values(), allow_unused=True)
+                        for key, grad_ in zip(param_require_grad.keys(), grad):
+                            if grad_ is None:
+                                continue
+                            net_para[key] = net_para[key] - args.fine_tune_lr * grad_
                     # net_para = list(
                     #                map(lambda p: p[1] - fine_tune_lr * p[0], zip(grad, net_para)))
                     # net_para={key:value for key, value in zip(net.state_dict().keys(),net.state_dict().values())}
@@ -495,14 +510,11 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                 loss_all += loss_ce(out_all, y_total)
                 loss_all.backward()
                 if args.use_dp:
+                    torch.nn.utils.clip_grad_norm_(net.parameters(), args.dp_clip)
                     for p in net.parameters():
                         if p.grad is not None:
-                            grad = p.grad
-                            clip_coeff = args.dp_clip / (grad.data.norm()+1e-6)
-                            if clip_coeff < 1:
-                                grad.data.mul_(clip_coeff)
-                            noise = torch.randn_like(grad) * args.dp_noise * args.dp_clip
-                            grad.data.add_(noise)
+                            noise = torch.randn_like(p.grad) * args.dp_noise * args.dp_clip / total_batch
+                            p.grad.add_(noise)
                 optimizer.step()
                 if accountant is not None:
                     accountant.step(
@@ -522,15 +534,30 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                         param_require_grad[key]=param
 
                 #meta-update few-classifier on query
-                loss = loss_ce(out, query_labels)
+                losses = F.cross_entropy(out, query_labels, reduction='none')
                 out_sup_on_N_class = out_all[N * K:, transformed_class_list]
-                loss += loss_ce(out,out_sup_on_N_class)*0
-                grad = torch.autograd.grad(loss, param_require_grad.values())
-                for key, grad_ in zip(param_require_grad.keys(), grad):
-                    if args.use_dp:
-                        grad_ = grad_.clamp(-args.dp_clip, args.dp_clip)
-                        grad_ = grad_ + torch.randn_like(grad_) * args.dp_noise * args.dp_clip
-                    net_para_ori[key]=net_para_ori[key]-args.meta_lr*grad_
+                aux_loss = F.cross_entropy(out, out_sup_on_N_class.detach(), reduction='none') * 0
+                losses = losses + aux_loss
+                if args.use_dp:
+                    per_sample_grads = []
+                    for i in range(losses.size(0)):
+                        grad_i = torch.autograd.grad(losses[i], param_require_grad.values(), retain_graph=True, allow_unused=True)
+                        per_sample_grads.append(grad_i)
+                    per_param_grads = []
+                    params_list = list(param_require_grad.values())
+                    for idx in range(len(params_list)):
+                        grads = []
+                        for g in per_sample_grads:
+                            grads.append(g[idx] if g[idx] is not None else torch.zeros_like(params_list[idx]))
+                        per_param_grads.append(torch.stack(grads))
+                    dp_grads = dp_clip_and_noise(per_param_grads, args.dp_clip, args.dp_noise)
+                    for key, grad_ in zip(param_require_grad.keys(), dp_grads):
+                        net_para_ori[key]=net_para_ori[key]-args.meta_lr*grad_
+                else:
+                    loss = losses.mean()
+                    grad = torch.autograd.grad(loss, param_require_grad.values())
+                    for key, grad_ in zip(param_require_grad.keys(), grad):
+                        net_para_ori[key]=net_para_ori[key]-args.meta_lr*grad_
                 net.load_state_dict(net_para_ori)
                 if accountant is not None:
                     accountant.step(

--- a/utils.py
+++ b/utils.py
@@ -452,3 +452,32 @@ def get_dataloader(dataset, datadir, train_bs, test_bs, dataidxs=None, noise_lev
         test_dl = data.DataLoader(dataset=test_ds, batch_size=test_bs, shuffle=False)
 
     return train_dl, test_dl, train_ds, test_ds
+from torch.nn.utils import clip_grad_norm_
+
+def dp_clip_and_noise(per_sample_grads, dp_clip, noise_multiplier):
+    """Clip per-sample gradients and add Gaussian noise.
+
+    Args:
+        per_sample_grads (List[Tensor]): List of gradients for each parameter with
+            shape [batch_size, *param_shape].
+        dp_clip (float): Clipping norm.
+        noise_multiplier (float): Multiplier for noise added after clipping.
+
+    Returns:
+        List[Tensor]: Noisy, clipped gradients averaged over the batch.
+    """
+    batch_size = per_sample_grads[0].size(0)
+    clipped = []
+    for i in range(batch_size):
+        params = [torch.nn.Parameter(torch.zeros_like(g[i])) for g in per_sample_grads]
+        for p, g in zip(params, per_sample_grads):
+            p.grad = g[i].clone()
+        clip_grad_norm_(params, dp_clip)
+        clipped.append([p.grad.clone() for p in params])
+    processed = []
+    for param_idx in range(len(per_sample_grads)):
+        stacked = torch.stack([clipped[s][param_idx] for s in range(batch_size)], dim=0)
+        mean_grad = stacked.mean(dim=0)
+        noise = torch.randn_like(mean_grad) * noise_multiplier * dp_clip / batch_size
+        processed.append(mean_grad + noise)
+    return processed


### PR DESCRIPTION
## Summary
- add `dp_clip_and_noise` to clip per-sample gradients with `clip_grad_norm_` and add scaled Gaussian noise
- update image and text training loops to compute per-sample gradients and apply DP clipping/noise
- switch to global norm clipping with noise scaled by batch size

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689037cec220832a800578d5c979e64a