### PR TITLE
Use generic device placement

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -94,7 +94,7 @@ def InforNCE_Loss(anchor, sample, tau, all_negative=False, temperature_matrix=No
 
     assert anchor.shape[0] == sample.shape[0]
 
-    pos_mask = torch.eye(anchor.shape[0], dtype=torch.float).cuda()
+    pos_mask = torch.eye(anchor.shape[0], dtype=torch.float).to(anchor.device)
     neg_mask = 1. - pos_mask
     sim = _similarity(anchor, sample / temperature_matrix if temperature_matrix != None else sample) / tau
     exp_sim = torch.exp(sim) * (pos_mask + neg_mask)
@@ -236,14 +236,11 @@ def init_nets(net_configs, n_parties, args, device='cpu'):
         if args.dataset=='20newsgroup':
             ebd=WordEmbed(args.finetune_ebd)
         for net_i in range(n_parties):
-            if args.dataset=='FC100' or args.dataset=='miniImageNet':
+            if args.dataset == 'FC100' or args.dataset == 'miniImageNet':
                 net = ModelFed_Adp(args.model, args.out_dim, n_classes, total_classes, net_configs, args)
             else:
-                net = LSTMAtt(WordEmbed(args.finetune_ebd), args.out_dim, n_classes, total_classes,args)
-            if device == 'cpu':
-                net.to(device)
-            else:
-                net = net.cuda()
+                net = LSTMAtt(WordEmbed(args.finetune_ebd), args.out_dim, n_classes, total_classes, args)
+            net.to(device)
             nets[net_i] = net
 
             
@@ -352,9 +349,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         query_labels = torch.zeros(N * Q, dtype=torch.long)
         for i in range(N):
             query_labels[i * Q:(i + 1) * Q] = i
-        if args.device != 'cpu':
-            support_labels = support_labels.cuda()
-            query_labels = query_labels.cuda()
+        support_labels = support_labels.to(args.device)
+        query_labels = query_labels.to(args.device)
 
         if mode == 'train':
             if args.dataset=='FC100':
@@ -421,7 +417,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
 
 
-                y_total = torch.cat([torch.cat(y_sup, 0), torch.cat(y_query, 0)], 0).long().cuda()
+                y_total = torch.cat([torch.cat(y_sup, 0), torch.cat(y_query, 0)], 0).long().to(args.device)
         #y_total=torch.tensor(np.concatenate([np.concatenate(y_sup, 0),np.concatenate(y_query, 0)],0)).cuda()
         
         X_total_sup=np.concatenate(X_total_sup, 0)
@@ -433,14 +429,14 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             X_total_transformed_query=[]
             for i in range(X_total_sup.shape[0]):
                 X_total_transformed_sup.append(X_transform(X_total_sup[i]))
-            X_total_sup=torch.stack(X_total_transformed_sup,0).cuda()
+            X_total_sup = torch.stack(X_total_transformed_sup, 0).to(args.device)
 
             for i in range(X_total_query.shape[0]):
                 X_total_transformed_query.append(X_transform(X_total_query[i]))
-            X_total_query=torch.stack(X_total_transformed_query,0).cuda()
+            X_total_query = torch.stack(X_total_transformed_query, 0).to(args.device)
         else:
-            X_total_sup=torch.tensor(X_total_sup).cuda()
-            X_total_query=torch.tensor(X_total_query).cuda()
+            X_total_sup = torch.tensor(X_total_sup, device=args.device)
+            X_total_query = torch.tensor(X_total_query, device=args.device)
 
 
 
@@ -611,7 +607,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
                     query_ys_pred = clf.predict(query_features)
 
-                    out=torch.tensor(clf.predict_proba(query_features)).cuda()
+                    out = torch.tensor(clf.predict_proba(query_features), device=query_labels.device)
 
                     acc_train = (torch.argmax(out, -1) == query_labels).float().mean().item()
                     max_value, index=torch.max(out,-1)
@@ -833,12 +829,11 @@ if __name__ == '__main__':
     support_labels=torch.zeros(N*K,dtype=torch.long)
     for i in range(N):
         support_labels[i * K:(i + 1) * K] = i
-    query_labels=torch.zeros(N*Q,dtype=torch.long)
+    query_labels = torch.zeros(N * Q, dtype=torch.long)
     for i in range(N):
         query_labels[i * Q:(i + 1) * Q] = i
-    if args.device!='cpu':
-        support_labels=support_labels.cuda()
-        query_labels=query_labels.cuda()
+    support_labels = support_labels.to(args.device)
+    query_labels = query_labels.to(args.device)
     
     
     n_party_per_round = int(args.n_parties * args.sample_fraction)


### PR DESCRIPTION
## Summary
- replace `.cuda()` calls with device-aware `.to(...)`
- remove `torch.cuda.LongTensor` usages in favor of `torch.arange(..., device=...)`
- update label and feature handling to respect runtime device

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6891aa0a5758832a878be35802b13444