### PR TITLE
Replace BatchNorm with GroupNorm for DP compliance

### DIFF
--- a/bn_utils.py
+++ b/bn_utils.py
@@ -1,0 +1,19 @@
+import torch.nn as nn
+
+
+def convert_batchnorm_modules(module):
+    """Replace all ``nn.BatchNorm2d`` layers with ``nn.GroupNorm``.
+
+    Parameters
+    ----------
+    module : nn.Module
+        Model to be converted in-place.
+    """
+    for name, child in module.named_children():
+        if isinstance(child, nn.BatchNorm2d):
+            gn = nn.GroupNorm(1, child.num_features, affine=child.affine, eps=child.eps)
+            setattr(module, name, gn)
+        else:
+            convert_batchnorm_modules(child)
+    return module
+

--- a/model.py
+++ b/model.py
@@ -6,9 +6,14 @@ import torchvision.models as models
 from resnetcifar import ResNet18_cifar10, ResNet50_cifar10
 from torch.distributions import Bernoulli
 from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
-from torchtext.vocab import GloVe
+try:
+    from torchtext.vocab import GloVe
+except Exception:  # pragma: no cover - optional dependency
+    GloVe = None
 from embedding.meta import RNN
 from embedding.auxiliary.factory import get_embedding
+from bn_utils import convert_batchnorm_modules
+from opacus.validators import ModuleValidator
 
 
 def l2_normalize(x):
@@ -213,7 +218,9 @@ class ResNet(nn.Module):
 def resnet12(keep_prob=1.0, avg_pool=False, drop_rate=0.0,**kwargs):
     """Constructs a ResNet-12 model.
     """
-    model = ResNet(BasicBlock, keep_prob=keep_prob, avg_pool=avg_pool,drop_rate=drop_rate, **kwargs)
+    model = ResNet(BasicBlock, keep_prob=keep_prob, avg_pool=avg_pool, drop_rate=drop_rate, **kwargs)
+    model = convert_batchnorm_modules(model)
+    ModuleValidator.validate(model, strict=True)
     return model
 
 

--- a/resnetcifar.py
+++ b/resnetcifar.py
@@ -7,6 +7,8 @@ Reference:
 
 import torch
 import torch.nn as nn
+from bn_utils import convert_batchnorm_modules
+from opacus.validators import ModuleValidator
 def conv3x3(in_planes, out_planes, stride=1, groups=1, dilation=1):
     """3x3 convolution with padding"""
     return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride,
@@ -211,7 +213,10 @@ def ResNet18_cifar10(**kwargs):
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
     """
-    return ResNetCifar10(BasicBlock, [2, 2, 2, 2], **kwargs)
+    model = ResNetCifar10(BasicBlock, [2, 2, 2, 2], **kwargs)
+    model = convert_batchnorm_modules(model)
+    ModuleValidator.validate(model, strict=True)
+    return model
 
 
 
@@ -223,4 +228,7 @@ def ResNet50_cifar10(**kwargs):
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
     """
-    return ResNetCifar10(Bottleneck, [3, 4, 6, 3], **kwargs)
+    model = ResNetCifar10(Bottleneck, [3, 4, 6, 3], **kwargs)
+    model = convert_batchnorm_modules(model)
+    ModuleValidator.validate(model, strict=True)
+    return model


### PR DESCRIPTION
## Summary
- add utility to replace `BatchNorm2d` layers with `GroupNorm`
- convert BatchNorm layers in ResNet builders and validate with `ModuleValidator`
- guard optional torchtext dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from model import resnet12
from resnetcifar import ResNet18_cifar10, ResNet50_cifar10

m1 = resnet12()
print('ResNet12 validated')

m2 = ResNet18_cifar10()
print('ResNet18 validated')

m3 = ResNet50_cifar10()
print('ResNet50 validated')
PY`


------
https://chatgpt.com/codex/tasks/task_e_6892cdee2038832aa13790617c39de83