### PR TITLE
Detach privacy engine after training

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -654,13 +654,13 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             max_values.append(max_value)
             indices.append(index)
             del acc, max_value, index
-
+        privacy_engine.detach()
         return np.mean(accs), torch.cat(max_values,0), torch.cat(indices,0)
 
     if np.random.rand()<0.3:
         print("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
     #logger.info("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
-
+    privacy_engine.detach()
     return  np.mean(accs)
 
 

--- a/main_text.py
+++ b/main_text.py
@@ -636,13 +636,13 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             max_values.append(max_value)
             indices.append(index)
             del acc, max_value, index
-
+        privacy_engine.detach()
         return np.mean(accs), torch.cat(max_values,0), torch.cat(indices,0)
 
     if np.random.rand()<0.3:
         print("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
     #logger.info("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
-
+    privacy_engine.detach()
     return  np.mean(accs)
 
 


### PR DESCRIPTION
## Summary
- Detach `PrivacyEngine` after training in `train_net_few_shot_new` for image and text workflows.
- Ensure privacy hooks are removed in both normal and test-only paths to restore original model/optimizer state.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6892e8fa98f8832ab653dfd544a044e1