### PR TITLE
Restore models after DP detach

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -660,14 +660,14 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             indices.append(index)
             del acc, max_value, index
         if privacy_engine is not None:
-            privacy_engine.detach()
+            gmodel, dp_optimizer, *_ = privacy_engine.detach()
         return np.mean(accs), torch.cat(max_values,0), torch.cat(indices,0)
 
     if np.random.rand()<0.3:
         print("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
     #logger.info("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
     if privacy_engine is not None:
-        privacy_engine.detach()
+        gmodel, dp_optimizer, *_ = privacy_engine.detach()
     return  np.mean(accs)
 
 

--- a/main_text.py
+++ b/main_text.py
@@ -642,14 +642,14 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             indices.append(index)
             del acc, max_value, index
         if privacy_engine is not None:
-            privacy_engine.detach()
+            gmodel, dp_optimizer, *_ = privacy_engine.detach()
         return np.mean(accs), torch.cat(max_values,0), torch.cat(indices,0)
 
     if np.random.rand()<0.3:
         print("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
     #logger.info("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
     if privacy_engine is not None:
-        privacy_engine.detach()
+        gmodel, dp_optimizer, *_ = privacy_engine.detach()
     return  np.mean(accs)
 
 


### PR DESCRIPTION
## Summary
- Restore `gmodel` and `dp_optimizer` after detaching the Opacus privacy engine in training scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6892ece42f64832abdc118c94683217a