### PR TITLE
Set correct DP sampling rate

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -371,7 +371,10 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         support_batch = N * K
         query_batch = N * Q
         total_batch = support_batch + query_batch
-        dp_optimizer.expected_batch_size = total_batch
+        sample_rate = total_batch / client_sample_size
+        if args.use_dp:
+            dp_optimizer.expected_batch_size = total_batch
+            dp_optimizer.sample_rate = sample_rate
 
         support_labels = torch.zeros(N * K, dtype=torch.long)
         for i in range(N):

--- a/main_text.py
+++ b/main_text.py
@@ -366,7 +366,10 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         support_batch = N * K
         query_batch = N * Q
         total_batch = support_batch + query_batch
-        dp_optimizer.expected_batch_size = total_batch
+        sample_rate = total_batch / client_sample_size
+        if args.use_dp:
+            dp_optimizer.expected_batch_size = total_batch
+            dp_optimizer.sample_rate = sample_rate
 
         support_labels = torch.zeros(N * K, dtype=torch.long)
         for i in range(N):


### PR DESCRIPTION
## Summary
- ensure DP optimizer updates expected batch size only when DP is enabled
- compute sample rate per client batch and assign to DP optimizer for accurate privacy accounting

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6892ece9692c832a8d00e30b5e7b3856