### PR TITLE
Ensure models return to train mode around DP wrapping

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -260,6 +260,7 @@ def init_nets(net_configs, n_parties, args, device='cpu'):
 def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_train_client, y_train_client, X_test, y_test,
                                         device='cpu', test_only=False, test_only_k=0):
     base_model = net
+    base_model.train()
     gmodel = base_model
 
     client_sample_size = len(y_train_client)
@@ -716,6 +717,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                         del p.grad_sample_stack
                 dp_optimizer = orig_optimizer
                 gmodel = base_model
+        base_model.train()
     return result
 def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_test, y_test, device='cpu', test_only=False, test_only_k=0):
     avg_acc = 0.0

--- a/main_text.py
+++ b/main_text.py
@@ -253,8 +253,8 @@ def init_nets(net_configs, n_parties, args, device='cpu'):
 
 def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_train_client, y_train_client, X_test, y_test,
                                         device='cpu', test_only=False, test_only_k=0):
-
     base_model = net
+    base_model.train()
     gmodel = base_model
 
     client_sample_size = len(y_train_client)
@@ -697,6 +697,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                         del p.grad_sample_stack
                 dp_optimizer = orig_optimizer
                 gmodel = base_model
+        base_model.train()
     return result
 def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_test, y_test, device='cpu', test_only=False, test_only_k=0):
     avg_acc = 0.0


### PR DESCRIPTION
## Summary
- Ensure `train_net_few_shot_new` switches the base model to training mode before differential privacy setup.
- After detaching the privacy engine, restore the base model to training mode for future rounds.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6892fafb482c832aa18299b30e59ddae