### PR TITLE
Clean up DP hooks before and after private training

### DIFF
--- a/dp_utils.py
+++ b/dp_utils.py
@@ -2,6 +2,22 @@ import math
 import torch
 
 
+def remove_dp_hooks(model):
+    """Remove differential privacy hooks and cached gradients.
+
+    This helper cleans up any Opacus hooks attached to ``model`` and deletes
+    gradient sample attributes that may have been added during private
+    training. It is safe to call multiple times.
+    """
+    if hasattr(model, 'autograd_grad_sample_hooks'):
+        for h in model.autograd_grad_sample_hooks.values():
+            h.remove()
+        model.autograd_grad_sample_hooks = {}
+    for p in model.parameters():
+        for attr in ('grad_sample', 'grad_sample_stack'):
+            if hasattr(p, attr):
+                delattr(p, attr)
+
 def compute_noisy_delta(global_params, local_params, clip_norm, noise_mult):
     """Compute clipped and noised updates for differential privacy.
 

--- a/main_text.py
+++ b/main_text.py
@@ -20,6 +20,7 @@ from model import *
 from model import WordEmbed
 from utils import *
 from opacus import PrivacyEngine
+from dp_utils import remove_dp_hooks
 import warnings
 from data.class_mappings import fine_id_coarse_id, coarse_id_fine_id, coarse_split
 
@@ -306,6 +307,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
     privacy_engine = None
     if args.use_dp:
+        remove_dp_hooks(base_model)
         noise_mult = getattr(args, 'dp_noise', 0.0)
         clip = getattr(args, 'dp_clip', 1.0)
         privacy_engine = PrivacyEngine(accountant='rdp')
@@ -691,14 +693,10 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                 privacy_engine = None
                 gmodel.train()
             else:
-                for p in gmodel.parameters():
-                    if hasattr(p, 'grad_sample'):
-                        del p.grad_sample
-                    if hasattr(p, 'grad_sample_stack'):
-                        del p.grad_sample_stack
                 dp_optimizer = orig_optimizer
                 gmodel = base_model
                 gmodel.train()
+            remove_dp_hooks(gmodel)
         base_model.train()
     return result
 def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_test, y_test, device='cpu', test_only=False, test_only_k=0):
@@ -709,6 +707,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
 
     for net_id, net in nets.items():
         print(net_id)
+        remove_dp_hooks(net)
 
         dataidxs = net_dataidx_map[net_id]
         n_epoch = args.epochs


### PR DESCRIPTION
## Summary
- add helper to strip Opacus gradient sample hooks
- ensure DP hooks are removed before enabling DP-SGD and after detaching
- clear hooks before each client's training call for safety

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6892ff88fbe4832a8984ea5c4ef500b9