### PR TITLE
Clean DP hooks for reusable models

### DIFF
--- a/dp_utils.py
+++ b/dp_utils.py
@@ -27,11 +27,11 @@ def remove_dp_hooks(model):
 
     for submodule in model.modules():
         hooks = getattr(submodule, 'autograd_grad_sample_hooks', None)
-        if hooks:
+        if hooks is not None:
             iterable = hooks.values() if isinstance(hooks, dict) else hooks
             for h in iterable:
                 h.remove()
-            submodule.autograd_grad_sample_hooks = [] if isinstance(hooks, list) else {}
+            delattr(submodule, 'autograd_grad_sample_hooks')
         for p in submodule.parameters(recurse=False):
             for attr in ('grad_sample', 'grad_sample_stack'):
                 if hasattr(p, attr):


### PR DESCRIPTION
## Summary
- ensure `remove_dp_hooks` deletes `autograd_grad_sample_hooks` attributes after clearing handles
- keep per-parameter `grad_sample` cleanup and return the base module for rewrapping

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689306b299c8832ab6c14ffe6bab0b98