### PR TITLE
Clean DP hooks before fine-tuning

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -530,8 +530,9 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     
     
     
-                if args.fine_tune_steps>0:
+                if args.fine_tune_steps > 0:
                     net_new = copy.deepcopy(base_model)
+                    net_new = remove_dp_hooks(net_new)
 
                     for j in range(args.fine_tune_steps):
                         net_new.zero_grad()


### PR DESCRIPTION
## Summary
- Remove Opacus DP hooks from copied model before meta fine-tuning.

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6893129ad890832a88543159a142173b