### PR TITLE
Separate few-shot head from DP optimizer

### DIFF
--- a/main_text.py
+++ b/main_text.py
@@ -260,11 +260,16 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
     client_sample_size = len(y_train_client)
 
-    dp_params = [p for n, p in base_model.named_parameters() if 'transform_layer' not in n and p.requires_grad]
+    dp_params = [
+        p for n, p in base_model.named_parameters()
+        if 'transform_layer' not in n and 'few_classify' not in n and p.requires_grad
+    ]
+    head_params = list(base_model.few_classify.parameters())
     tl_params = [p for n, p in base_model.named_parameters() if 'transform_layer' in n and p.requires_grad]
 
     if args_optimizer == 'adam':
         dp_optimizer = optim.Adam(dp_params, lr=lr, weight_decay=args.reg)
+        head_optimizer = optim.Adam(head_params, lr=lr, weight_decay=args.reg)
     elif args_optimizer == 'amsgrad':
         dp_optimizer = optim.Adam(
             dp_params,
@@ -272,9 +277,21 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             weight_decay=args.reg,
             amsgrad=True,
         )
+        head_optimizer = optim.Adam(
+            head_params,
+            lr=lr,
+            weight_decay=args.reg,
+            amsgrad=True,
+        )
     elif args_optimizer == 'sgd':
         dp_optimizer = optim.SGD(
             dp_params,
+            lr=lr,
+            momentum=0.9,
+            weight_decay=args.reg,
+        )
+        head_optimizer = optim.SGD(
+            head_params,
             lr=lr,
             momentum=0.9,
             weight_decay=args.reg,
@@ -334,7 +351,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     try:
 
         def train_epoch(epoch, mode='train'):
-            nonlocal dp_optimizer, tl_optimizer, gmodel, base_model
+            nonlocal dp_optimizer, head_optimizer, tl_optimizer, gmodel, base_model
     
             if mode == 'train':
     
@@ -360,6 +377,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     Q = args.Q
                 gmodel.train()
                 dp_optimizer.zero_grad()
+                head_optimizer.zero_grad()
                 if tl_optimizer is not None:
                     tl_optimizer.zero_grad()
                 if args.dataset == 'FC100':
@@ -552,6 +570,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     loss_all += loss_ce(out_all, y_total)
                     loss_all.backward()
                     dp_optimizer.step()
+                    head_optimizer.step()
                     if tl_optimizer is not None:
                         tl_optimizer.step()
                     if args.use_dp and privacy_engine is not None:


### PR DESCRIPTION
## Summary
- Exclude `few_classify` parameters from the DP optimizer
- Introduce a dedicated optimizer for `few_classify` and update it separately

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689311d1efc8832ab7bcde79a901dec4