### PR TITLE
Preserve DP model template for fine-tuning

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -263,6 +263,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     base_model = net
     base_model.train()
     gmodel = base_model
+    model_template = copy.deepcopy(base_model)   # DP-free template
 
     client_sample_size = len(y_train_client)
 
@@ -554,8 +555,9 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     
     
                 if args.fine_tune_steps > 0:
-                    net_new = copy.deepcopy(gmodel._module if hasattr(gmodel, '_module') else gmodel)
-                    net_new = remove_dp_hooks(net_new)
+                    gmodel_base = gmodel._module if hasattr(gmodel, '_module') else gmodel
+                    net_new = copy.deepcopy(model_template)
+                    net_new.load_state_dict(gmodel_base.state_dict())
 
                     for j in range(args.fine_tune_steps):
                         net_new.zero_grad()


### PR DESCRIPTION
## Summary
- Keep a DP-free copy of the base model before attaching `PrivacyEngine`
- Rebuild inner fine-tuning model from the template and load weights from DP-wrapped model
- Apply pattern to both image and text training pipelines

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689439493ebc832aa7d50a1e2674fcf5