### PR TITLE
Use GradSampleModule hook toggles for inference

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -596,10 +596,10 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                         if 'transformer' in name:
                             param.requires_grad_(False)
                     if isinstance(gmodel, GradSampleModule):
-                        gmodel.set_grad_sample_enabled(False)
+                        gmodel.disable_hooks()
                     X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
                     if isinstance(gmodel, GradSampleModule):
-                        gmodel.set_grad_sample_enabled(True)
+                        gmodel.enable_hooks()
                     for name, param in gmodel.named_parameters():
                         if 'transformer' in name:
                             param.requires_grad_(True)

--- a/main_text.py
+++ b/main_text.py
@@ -594,10 +594,10 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                         if 'transformer' in name:
                             param.requires_grad_(False)
                     if isinstance(gmodel, GradSampleModule):
-                        gmodel.set_grad_sample_enabled(False)
+                        gmodel.disable_hooks()
                     X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
                     if isinstance(gmodel, GradSampleModule):
-                        gmodel.set_grad_sample_enabled(True)
+                        gmodel.enable_hooks()
                     for name, param in gmodel.named_parameters():
                         if 'transformer' in name:
                             param.requires_grad_(True)


### PR DESCRIPTION
## Summary
- replace deprecated `set_grad_sample_enabled` calls with `disable_hooks`/`enable_hooks` in image and text training loops
- ensure GradSampleModule hooks are toggled around inference-only forward passes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6894439ad2a4832a89cc3c1526cec2d0