### PR TITLE
Avoid gradients in secondary gmodel forward

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -593,7 +593,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                             param.requires_grad_(False)
                     if isinstance(gmodel, GradSampleModule):
                         gmodel.disable_hooks()
-                    X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
+                    with torch.no_grad():
+                        X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
                     if isinstance(gmodel, GradSampleModule):
                         gmodel.enable_hooks()
                     for name, param in gmodel.named_parameters():

--- a/main_text.py
+++ b/main_text.py
@@ -591,7 +591,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                             param.requires_grad_(False)
                     if isinstance(gmodel, GradSampleModule):
                         gmodel.disable_hooks()
-                    X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
+                    with torch.no_grad():
+                        X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
                     if isinstance(gmodel, GradSampleModule):
                         gmodel.enable_hooks()
                     for name, param in gmodel.named_parameters():


### PR DESCRIPTION
## Summary
- prevent gradient tracking during the second `gmodel` forward in `train_epoch` for image and text training

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68944e376b24832ab11068f379047a41