### PR TITLE
Log epsilon only after each round

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -726,11 +726,6 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                 del acc, max_value, index
             result = (np.mean(accs), torch.cat(max_values, 0), torch.cat(indices, 0))
 
-        if args.use_dp and privacy_engine is not None and args.print_eps:
-            epsilon = privacy_engine.accountant.get_epsilon(args.dp_delta)
-            print('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
-            logger.info('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
-
         if np.random.rand() < 0.3:
             print('Meta-test_Accuracy: {:.4f}'.format(np.mean(accs)))
         #logger.info("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
@@ -1039,7 +1034,11 @@ if __name__ == '__main__':
 
             print('>> Current Round: {}'.format(round))
             logger.info('>> Current Round: {}'.format(round))
-            
+            if args.use_dp and privacy_engine is not None and args.print_eps:
+                epsilon = privacy_engine.accountant.get_epsilon(args.dp_delta)
+                print('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
+                logger.info('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
+
             mkdirs(args.modeldir+'fedavg/')
 
             if global_acc > best_acc:

--- a/main_text.py
+++ b/main_text.py
@@ -715,11 +715,6 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                 del acc, max_value, index
             result = (np.mean(accs), torch.cat(max_values, 0), torch.cat(indices, 0))
 
-        if args.use_dp and privacy_engine is not None and args.print_eps:
-            epsilon = privacy_engine.accountant.get_epsilon(args.dp_delta)
-            print('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
-            logger.info('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
-
         if np.random.rand() < 0.3:
             print('Meta-test_Accuracy: {:.4f}'.format(np.mean(accs)))
         #logger.info("Meta-test_Accuracy: {:.4f}".format(np.mean(accs)))
@@ -1009,7 +1004,11 @@ if __name__ == '__main__':
 
             print('>> Current Round: {}'.format(round))
             logger.info('>> Current Round: {}'.format(round))
-            
+            if args.use_dp and privacy_engine is not None and args.print_eps:
+                epsilon = privacy_engine.accountant.get_epsilon(args.dp_delta)
+                print('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
+                logger.info('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
+
             mkdirs(args.modeldir+'fedavg/')
 
             if global_acc > best_acc:


### PR DESCRIPTION
## Summary
- remove redundant epsilon logging during evaluations
- report privacy epsilon after each training round only

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689453659414832a81b656c246de8ebc