### PR TITLE
Refactor dataset parameter selection for few-shot tasks

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -307,26 +307,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
     orig_optimizer = dp_optimizer
 
-    if args.dataset == 'fewrel':
-        N = args.N * 3
-        K = 2
-        Q = 2
-    elif args.dataset == 'huffpost':
-        N = args.N
-        K = 5
-        Q = args.Q
-    elif args.dataset == 'FC100':
-        N = args.N * 4
-        K = 2
-        Q = 2
-    elif args.dataset == 'miniImageNet':
-        N = args.N * 4
-        K = 2
-        Q = 2
-    else:
-        N = args.N
-        K = 5
-        Q = args.Q
+    N, K, Q = get_n_k_q(args, mode='train', fewrel_multiplier=3)
     total_batch = N * K + N * Q
     sample_rate = total_batch / client_sample_size
 
@@ -362,27 +343,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             nonlocal dp_optimizer, head_optimizer, tl_optimizer, gmodel, base_model
     
             if mode == 'train':
-    
-                if args.dataset=='fewrel' :
-                    N=args.N*3
-                    K=2
-                    Q=2
-                elif args.dataset=='huffpost':
-                    N = args.N
-                    K = 5#args.K
-                    Q = args.Q
-                elif args.dataset=='FC100':
-                    N=args.N*4
-                    K=2
-                    Q=2
-                elif args.dataset=='miniImageNet':
-                    N=args.N*4
-                    K=2
-                    Q=2
-                else:
-                    N = args.N
-                    K = 5#args.K
-                    Q = args.Q
+                N, K, Q = get_n_k_q(args, mode='train', fewrel_multiplier=3)
                 gmodel.train()
                 gmodel.zero_grad(set_to_none=True)  # clears param.grad and param.grad_sample
                 dp_optimizer.zero_grad()
@@ -414,9 +375,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     ])
     
             else:
-                N=args.N
-                K=args.K
-                Q=args.Q
+                N, K, Q = get_n_k_q(args, mode='test', fewrel_multiplier=3)
                 #N=args.N*2
                 gmodel.eval()
                 if args.dataset == 'FC100':

--- a/main_text.py
+++ b/main_text.py
@@ -301,26 +301,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
     orig_optimizer = dp_optimizer
 
-    if args.dataset == 'fewrel':
-        N = args.N * 4
-        K = 2
-        Q = 2
-    elif args.dataset == 'huffpost':
-        N = args.N
-        K = 5
-        Q = args.Q
-    elif args.dataset == 'FC100':
-        N = args.N * 4
-        K = 2
-        Q = 2
-    elif args.dataset == 'miniImageNet':
-        N = args.N * 4
-        K = 2
-        Q = 2
-    else:
-        N = args.N
-        K = 5
-        Q = args.Q
+    N, K, Q = get_n_k_q(args, mode='train')
     total_batch = N * K + N * Q
     sample_rate = total_batch / client_sample_size
 
@@ -356,28 +337,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             nonlocal dp_optimizer, head_optimizer, tl_optimizer, gmodel, base_model
     
             if mode == 'train':
-                loss_all=0
-    
-                if args.dataset=='fewrel' :
-                    N=args.N*4
-                    K=2
-                    Q=2
-                elif args.dataset=='huffpost':
-                    N = args.N
-                    K = 5#args.K
-                    Q = args.Q
-                elif args.dataset=='FC100':
-                    N=args.N*4
-                    K=2
-                    Q=2
-                elif args.dataset=='miniImageNet':
-                    N=args.N*4
-                    K=2
-                    Q=2
-                else:
-                    N = args.N
-                    K = 5#args.K
-                    Q = args.Q
+                loss_all = 0
+                N, K, Q = get_n_k_q(args, mode='train')
                 gmodel.train()
                 gmodel.zero_grad(set_to_none=True)  # clears param.grad and param.grad_sample
                 dp_optimizer.zero_grad()
@@ -409,9 +370,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     ])
     
             else:
-                N=args.N
-                K=args.K
-                Q=args.Q
+                N, K, Q = get_n_k_q(args, mode='test')
                 #N=args.N*2
                 gmodel.eval()
                 if args.dataset == 'FC100':

--- a/utils.py
+++ b/utils.py
@@ -18,6 +18,28 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
+def get_n_k_q(args, mode='train', fewrel_multiplier=4):
+    '''Return dataset-specific N, K and Q values.
+
+    Args:
+        args: Argument namespace containing dataset configuration.
+        mode: Either 'train' or 'test'. Defaults to 'train'.
+        fewrel_multiplier: Multiplier applied to N for the 'fewrel' dataset.
+
+    Returns:
+        Tuple of integers representing (N, K, Q).
+    '''
+    if mode == 'train':
+        if args.dataset == 'fewrel':
+            return args.N * fewrel_multiplier, 2, 2
+        if args.dataset == 'huffpost':
+            return args.N, 5, args.Q
+        if args.dataset in {'FC100', 'miniImageNet'}:
+            return args.N * 4, 2, 2
+        return args.N, 5, args.Q
+    return args.N, args.K, args.Q
+
+
 def mkdirs(dirpath):
     try:
         os.makedirs(dirpath)


### PR DESCRIPTION
## Summary
- centralize dataset-specific N/K/Q logic in new `get_n_k_q` helper
- use shared helper during setup and `train_epoch` in `main_image.py`
- use shared helper during setup and `train_epoch` in `main_text.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689551e55688832ab4573b40b4ef1e56