### PR TITLE
Use no_grad for logistic regression predictions

### DIFF
--- a/model.py
+++ b/model.py
@@ -55,13 +55,15 @@ class LogisticRegression(nn.Module):
 
         optimizer.step(closure)
 
+    @torch.no_grad()
     def predict_proba(self, X):
         '''Return class probabilities for ``X``.'''
-        return F.softmax(self.forward(X), dim=-1)
+        return F.softmax(self.forward(X), dim=-1).to(X.device)
 
+    @torch.no_grad()
     def predict(self, X):
         '''Return class predictions for ``X``.'''
-        return torch.argmax(self.predict_proba(X), dim=-1)
+        return torch.argmax(self.predict_proba(X), dim=-1).to(X.device)
 
 
 class TransformLayer(nn.Module):


### PR DESCRIPTION
## Summary
- Avoid gradient tracking during logistic regression predictions by decorating `predict_proba` and `predict` with `torch.no_grad`
- Ensure prediction outputs stay on the same device as inputs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68958c4ed384832a81730a20dce6ec66