### PR TITLE
Ensure CIFAR10 dataset uses PIL images for transforms

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -69,7 +69,7 @@ class CIFAR10_truncated(data.Dataset):
             tuple: (image, target) where target is index of the target class.
         """
         img, target = self.data[index], self.target[index]
-        # img = Image.fromarray(img)
+        img = Image.fromarray(img)
         # print("cifar10 img:", img)
         # print("cifar10 target:", target)
 

--- a/tests/test_cifar10_truncated_transform.py
+++ b/tests/test_cifar10_truncated_transform.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import numpy as np
+from torchvision import transforms
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from datasets import CIFAR10_truncated
+
+
+def test_cifar10_truncated_pil_transform():
+    """CIFAR10_truncated should handle PIL-based transforms."""
+    dataset = CIFAR10_truncated.__new__(CIFAR10_truncated)
+    dataset.data = np.random.randint(0, 255, (1, 32, 32, 3), dtype=np.uint8)
+    dataset.target = np.array([0])
+    dataset.transform = transforms.Compose([
+        transforms.RandomHorizontalFlip(),
+        transforms.ToTensor(),
+    ])
+    dataset.target_transform = None
+    img, target = dataset[0]
+    assert img.shape[0] == 3
+    assert target == 0


### PR DESCRIPTION
## Summary
- convert CIFAR10_truncated samples to PIL images before applying transforms
- add unit test to check torchvision transforms on CIFAR10_truncated

## Testing
- `python tests/test_cifar10_truncated_transform.py`
- `python -m py_compile $(git ls-files '*.py') tests/test_cifar10_truncated_transform.py`


------
https://chatgpt.com/codex/tasks/task_e_689596ce567c832a96a5d8f6c001aa2d