### PR TITLE
Handle epsilon from few-shot training call

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -715,8 +715,11 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
 
         if test_only==False:
             net.train()
-            train_net_few_shot_new(net_id, net, n_epoch, args.lr, args.optimizer, args, X_train_client, y_train_client, X_test, y_test,
-                                        device=device, test_only=False)
+            result, epsilon = train_net_few_shot_new(
+                net_id, net, n_epoch, args.lr, args.optimizer, args, X_train_client, y_train_client, X_test, y_test,
+                device=device, test_only=False
+            )
+            testacc = result
         else:
             net.train()
             result, _ = train_net_few_shot_new(net_id, net, n_epoch, args.lr, args.optimizer, args, X_train_client, y_train_client, X_test, y_test,


### PR DESCRIPTION
## Summary
- Capture return value and epsilon from `train_net_few_shot_new` in `local_train_net_few_shot`
- Preserve test accuracy and epsilon for later computations to avoid `UnboundLocalError`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import main_image
from types import SimpleNamespace
import numpy as np

class DummyNet:
    def train(self):
        pass

main_image.train_net_few_shot_new = lambda *args, **kwargs: (0.5, 0.1)

nets = {0: DummyNet()}
args = SimpleNamespace(epochs=1, lr=0.01, optimizer='sgd', n_parties=1, alg='local_training', use_dp=False)
net_dataidx_map = {0: np.array([0])}
X_train = np.array([[0.0]])
y_train = np.array([0])
X_test = np.array([[0.0]])
y_test = np.array([0])

result_nets, epsilon = main_image.local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_test, y_test, device='cpu')
print('epsilon', epsilon)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689d8c8f1bc4832a9b2111ec912cef90