### PR TITLE
Add PRV accountant option

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -194,6 +194,8 @@ def get_args():
     parser.add_argument('--dp_noise', type=float, default=0.0, help='DP-SGD noise multiplier')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_mode', choices=['local', 'server', 'off'], default='server')
+    parser.add_argument('--dp_accountant', choices=['rdp', 'prv'], default='rdp',
+                        help='DP accountant to estimate the privacy budget')
     parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
     args = parser.parse_args()
     args.use_dp = int(args.dp_mode != 'off')
@@ -979,7 +981,7 @@ if __name__ == '__main__':
                     dp_steps,
                     args.dp_noise,
                     args.dp_delta,
-                    accountant='rdp',
+                    accountant=args.dp_accountant,
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
 

--- a/main_text.py
+++ b/main_text.py
@@ -188,6 +188,8 @@ def get_args():
     parser.add_argument('--dp_noise', type=float, default=0.0, help='DP-SGD noise multiplier')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_mode', choices=['local', 'server', 'off'], default='server')
+    parser.add_argument('--dp_accountant', choices=['rdp', 'prv'], default='rdp',
+                        help='DP accountant to estimate the privacy budget')
     parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
     args = parser.parse_args()
     args.use_dp = int(args.dp_mode != 'off')
@@ -965,7 +967,7 @@ if __name__ == '__main__':
                     dp_steps,
                     args.dp_noise,
                     args.dp_delta,
-                    accountant='rdp',
+                    accountant=args.dp_accountant,
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
 


### PR DESCRIPTION
## Summary
- support PRV/PLD accounting option in `dp_utils.compute_epsilon`
- expose `--dp_accountant` flag in training scripts to choose accounting method

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a3f0bab224832aae61a6b4014df11a