### PR TITLE
Add DPAdam optimizer and convergence monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The repository now includes optional support for a **personalised transformation
   * `--dp_noise`: noise multiplier
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)
   * `--print_eps`: output the current ε after each communication round when set to `1`
+* Server momentum can be enabled with `--server_momentum <beta>` to use FedAvgM.
+* Set `--optimizer dpadam` to train with the DPAdam optimizer when using differential privacy.
+* Use `--convergence_threshold <value>` to stop early once the global model change falls below the given value.
 
 Examples:
 

--- a/main_image.py
+++ b/main_image.py
@@ -19,6 +19,7 @@ from model import WordEmbed
 from utils import *
 from opacus import PrivacyEngine
 from opacus.grad_sample import GradSampleModule
+from opacus.optimizers import DPAdam
 import dp_utils
 from dp_utils import remove_dp_hooks
 import warnings
@@ -197,6 +198,8 @@ def get_args():
     parser.add_argument('--dp_accountant', choices=['rdp', 'prv'], default='rdp',
                         help='DP accountant to estimate the privacy budget')
     parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
+    parser.add_argument('--convergence_threshold', type=float, default=0.0,
+                        help='early stop when global model change falls below this value')
     args = parser.parse_args()
     args.use_dp = int(args.dp_mode != 'off')
     return args
@@ -267,21 +270,38 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     base_model = net
     base_model.train()
     gmodel = base_model
+    if args_optimizer == 'dpadam':
+        gmodel = GradSampleModule(base_model)
     model_template = copy.deepcopy(base_model)   # DP-free template
 
     client_sample_size = len(y_train_client)
 
     dp_named_params = [
-        (n, p) for n, p in base_model.named_parameters()
+        (n, p) for n, p in gmodel.named_parameters()
         if 'transform_layer' not in n and 'few_classify' not in n and 'transformer' not in n and p.requires_grad
     ]
     dp_params = [p for _, p in dp_named_params]
-    head_params = list(base_model.few_classify.parameters())
-    tl_params = [p for n, p in base_model.named_parameters() if 'transform_layer' in n and p.requires_grad]
+    head_params = list(gmodel.few_classify.parameters())
+    tl_params = [p for n, p in gmodel.named_parameters() if 'transform_layer' in n and p.requires_grad]
 
     if args_optimizer == 'adam':
         dp_optimizer = optim.Adam(dp_params, lr=lr, weight_decay=args.reg)
         head_optimizer = optim.Adam(head_params, lr=lr, weight_decay=args.reg)
+    elif args_optimizer == 'dpadam':
+        dp_optimizer = DPAdam(
+            dp_params,
+            lr=lr,
+            weight_decay=args.reg,
+            noise_multiplier=getattr(args, 'dp_noise', 0.0),
+            max_grad_norm=getattr(args, 'dp_clip', 1.0),
+        )
+        head_optimizer = DPAdam(
+            head_params,
+            lr=lr,
+            weight_decay=args.reg,
+            noise_multiplier=getattr(args, 'dp_noise', 0.0),
+            max_grad_norm=getattr(args, 'dp_clip', 1.0),
+        )
     elif args_optimizer == 'amsgrad':
         dp_optimizer = optim.Adam(
             dp_params,
@@ -316,7 +336,12 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     sample_rate = total_batch / client_sample_size
 
     privacy_engine = None
-    if args.dp_mode == 'local' and dp_params:
+    if args_optimizer == 'dpadam':
+        dp_optimizer.sample_rate = sample_rate
+        dp_optimizer.expected_batch_size = total_batch
+        head_optimizer.sample_rate = sample_rate
+        head_optimizer.expected_batch_size = total_batch
+    elif args.dp_mode == 'local' and dp_params:
         noise_mult = getattr(args, 'dp_noise', 0.0)
         clip = getattr(args, 'dp_clip', 1.0)
         privacy_engine = PrivacyEngine(accountant='rdp')
@@ -928,9 +953,10 @@ if __name__ == '__main__':
             #logger.info("in comm round:" + str(round))
             party_list_this_round = party_list_rounds[round]
 
-            global_w = global_model.state_dict()
+            prev_global_w = copy.deepcopy(global_model.state_dict())
+            global_w = copy.deepcopy(prev_global_w)
             if args.server_momentum:
-                old_w = copy.deepcopy(global_model.state_dict())
+                old_w = copy.deepcopy(prev_global_w)
 
             nets_this_round = {k: nets[k] for k in party_list_this_round}
             participating_ids = list(nets_this_round.keys())
@@ -1011,6 +1037,14 @@ if __name__ == '__main__':
                     delta_w[key] = old_w[key] - global_w[key]
                     moment_v[key] = args.server_momentum * moment_v[key] + (1-args.server_momentum) * delta_w[key]
                     global_w[key] = old_w[key] - moment_v[key]
+
+            if args.convergence_threshold:
+                diff = torch.sqrt(sum(torch.sum((prev_global_w[k] - global_w[k]) ** 2) for k in global_w))
+                if diff < args.convergence_threshold:
+                    print(f'Converged with global model change {diff.item():.6f}, stopping.')
+                    logger.info(f'Converged with global model change {diff.item():.6f}, stopping.')
+                    global_model.load_state_dict(global_w)
+                    break
 
             global_model.load_state_dict(global_w)
 

--- a/main_text.py
+++ b/main_text.py
@@ -19,6 +19,7 @@ from model import WordEmbed
 from utils import *
 from opacus import PrivacyEngine
 from opacus.grad_sample import GradSampleModule
+from opacus.optimizers import DPAdam
 import dp_utils
 from dp_utils import remove_dp_hooks
 import warnings
@@ -191,6 +192,8 @@ def get_args():
     parser.add_argument('--dp_accountant', choices=['rdp', 'prv'], default='rdp',
                         help='DP accountant to estimate the privacy budget')
     parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
+    parser.add_argument('--convergence_threshold', type=float, default=0.0,
+                        help='early stop when global model change falls below this value')
     args = parser.parse_args()
     args.use_dp = int(args.dp_mode != 'off')
     return args
@@ -261,21 +264,38 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     base_model = net
     base_model.train()
     gmodel = base_model
+    if args_optimizer == 'dpadam':
+        gmodel = GradSampleModule(base_model)
     model_template = copy.deepcopy(base_model)   # DP-free template
 
     client_sample_size = len(y_train_client)
 
     dp_named_params = [
-        (n, p) for n, p in base_model.named_parameters()
+        (n, p) for n, p in gmodel.named_parameters()
         if 'transform_layer' not in n and 'few_classify' not in n and 'transformer' not in n and p.requires_grad
     ]
     dp_params = [p for _, p in dp_named_params]
-    head_params = list(base_model.few_classify.parameters())
-    tl_params = [p for n, p in base_model.named_parameters() if 'transform_layer' in n and p.requires_grad]
+    head_params = list(gmodel.few_classify.parameters())
+    tl_params = [p for n, p in gmodel.named_parameters() if 'transform_layer' in n and p.requires_grad]
 
     if args_optimizer == 'adam':
         dp_optimizer = optim.Adam(dp_params, lr=lr, weight_decay=args.reg)
         head_optimizer = optim.Adam(head_params, lr=lr, weight_decay=args.reg)
+    elif args_optimizer == 'dpadam':
+        dp_optimizer = DPAdam(
+            dp_params,
+            lr=lr,
+            weight_decay=args.reg,
+            noise_multiplier=getattr(args, 'dp_noise', 0.0),
+            max_grad_norm=getattr(args, 'dp_clip', 1.0),
+        )
+        head_optimizer = DPAdam(
+            head_params,
+            lr=lr,
+            weight_decay=args.reg,
+            noise_multiplier=getattr(args, 'dp_noise', 0.0),
+            max_grad_norm=getattr(args, 'dp_clip', 1.0),
+        )
     elif args_optimizer == 'amsgrad':
         dp_optimizer = optim.Adam(
             dp_params,
@@ -310,7 +330,12 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     sample_rate = total_batch / client_sample_size
 
     privacy_engine = None
-    if args.dp_mode == 'local' and dp_params:
+    if args_optimizer == 'dpadam':
+        dp_optimizer.sample_rate = sample_rate
+        dp_optimizer.expected_batch_size = total_batch
+        head_optimizer.sample_rate = sample_rate
+        head_optimizer.expected_batch_size = total_batch
+    elif args.dp_mode == 'local' and dp_params:
         noise_mult = getattr(args, 'dp_noise', 0.0)
         clip = getattr(args, 'dp_clip', 1.0)
         privacy_engine = PrivacyEngine(accountant='rdp')
@@ -915,9 +940,10 @@ if __name__ == '__main__':
             #logger.info("in comm round:" + str(round))
             party_list_this_round = party_list_rounds[round]
 
-            global_w = global_model.state_dict()
+            prev_global_w = copy.deepcopy(global_model.state_dict())
+            global_w = copy.deepcopy(prev_global_w)
             if args.server_momentum:
-                old_w = copy.deepcopy(global_model.state_dict())
+                old_w = copy.deepcopy(prev_global_w)
 
             nets_this_round = {k: nets[k] for k in party_list_this_round}
             participating_ids = list(nets_this_round.keys())
@@ -996,6 +1022,14 @@ if __name__ == '__main__':
                     delta_w[key] = old_w[key] - global_w[key]
                     moment_v[key] = args.server_momentum * moment_v[key] + (1-args.server_momentum) * delta_w[key]
                     global_w[key] = old_w[key] - moment_v[key]
+
+            if args.convergence_threshold:
+                diff = torch.sqrt(sum(torch.sum((prev_global_w[k] - global_w[k]) ** 2) for k in global_w))
+                if diff < args.convergence_threshold:
+                    print(f'Converged with global model change {diff.item():.6f}, stopping.')
+                    logger.info(f'Converged with global model change {diff.item():.6f}, stopping.')
+                    global_model.load_state_dict(global_w)
+                    break
 
             global_model.load_state_dict(global_w)
 


### PR DESCRIPTION
## Summary
- allow `--optimizer dpadam` to train with Opacus' DPAdam optimizer
- add `--convergence_threshold` flag to stop rounds when global model change is small
- document server momentum, DPAdam, and convergence threshold in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a4084b3200832a9ad965a9189ec48d