### PR TITLE
Add DP-friendly optimizer and convergence monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ python main_image.py --dataset miniImageNet --dp_mode off
 ```
 When `--print_eps 1`, the current ε and δ are printed after each round.
 
+* Enable server momentum with `--server_momentum <m>` to use FedAvgM for faster convergence.
+* Select DP-compatible optimizers via `--optimizer`. In addition to `sgd`, `adam`, and `amsgrad`, `adamw` is supported and becomes DP-AdamW when differential privacy is enabled.
+* Training can stop early when global accuracy plateaus. Set `--convergence_patience` and `--convergence_delta` to monitor convergence and exit before reaching the full `--comm_round`.
+
 ### Choosing a noise multiplier for a target ε
 
 The helper `find_noise_multiplier` in `dp_utils.py` searches for a noise multiplier that achieves a desired privacy budget:

--- a/main_image.py
+++ b/main_image.py
@@ -137,7 +137,8 @@ def get_args():
     parser.add_argument('--fine_tune_lr', type=float, default=0.1, help='number of meta-learning lr (0.05)')
     parser.add_argument('--meta_lr', type=float, default=0.1/100, help='number of meta-learning lr (0.05)')
     parser.add_argument('--comm_round', type=int, default=5000, help='number of maximum communication roun')
-    parser.add_argument('--optimizer', type=str, default='sgd', help='the optimizer')
+    parser.add_argument('--optimizer', type=str, default='sgd',
+                        help='optimizer: sgd, adam, amsgrad, or adamw')
     
     
     parser.add_argument("--bert_cache_dir", default=None, type=str,
@@ -187,6 +188,10 @@ def get_args():
     parser.add_argument('--save_model',type=int,default=0)
     parser.add_argument('--use_project_head', type=int, default=1)
     parser.add_argument('--server_momentum', type=float, default=0, help='the server momentum (FedAvgM)')
+    parser.add_argument('--convergence_patience', type=int, default=0,
+                        help='stop if accuracy does not improve after this many rounds (0 to disable)')
+    parser.add_argument('--convergence_delta', type=float, default=0.0,
+                        help='minimum accuracy improvement to reset patience')
     parser.add_argument('--use_transform_layer', type=int, default=0,
                         help='enable personalized transformation layer')
     parser.add_argument('--use_dp', type=int, default=0, help='enable DP-SGD')
@@ -295,6 +300,9 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             weight_decay=args.reg,
             amsgrad=True,
         )
+    elif args_optimizer == 'adamw':
+        dp_optimizer = optim.AdamW(dp_params, lr=lr, weight_decay=args.reg)
+        head_optimizer = optim.AdamW(head_params, lr=lr, weight_decay=args.reg)
     elif args_optimizer == 'sgd':
         dp_optimizer = optim.SGD(
             dp_params,
@@ -919,9 +927,10 @@ if __name__ == '__main__':
             moment_v[key] = 0
     if args.alg == 'fedavg':
         use_minus=False
-        best_acc=0
-        best_acc_5=0
-        best_confident_acc=0
+        best_acc = 0
+        best_acc_5 = 0
+        best_confident_acc = 0
+        no_improve = 0
 
         dp_steps = 0
         for round in range(n_comm_rounds):
@@ -954,12 +963,14 @@ if __name__ == '__main__':
             for k in [1,5]:
                 global_acc, max_value_all_clients, indices_all_clients, _ = local_train_net_few_shot(nets_this_round, args, net_dataidx_map, X_train, y_train, X_test, y_test, device=device, test_only=True, test_only_k=k)
                 global_acc = max(global_acc)
-                if k==1:
-                    if global_acc > best_acc:
+                if k == 1:
+                    if global_acc > best_acc + args.convergence_delta:
                         best_acc = global_acc
+                        no_improve = 0
+                    else:
+                        no_improve += 1
                     print('>> Global 1 Model Test accuracy: {:.4f} Best Acc: {:.4f}'.format(global_acc, best_acc))
-                    logger.info(
-                        '>> Global 1 Model Test accuracy: {:.4f} Best Acc: {:.4f} '.format(global_acc, best_acc))
+                    logger.info('>> Global 1 Model Test accuracy: {:.4f} Best Acc: {:.4f} '.format(global_acc, best_acc))
                 elif k==5:
                     if global_acc > best_acc_5:
                         best_acc_5 = global_acc
@@ -1028,3 +1039,8 @@ if __name__ == '__main__':
             if global_acc > best_acc:
                 torch.save(global_model.state_dict(), args.modeldir+'fedavg/'+'globalmodel'+args.log_file_name+'.pth')
                 torch.save(nets[0].state_dict(), args.modeldir+'fedavg/'+'localmodel0'+args.log_file_name+'.pth')
+
+            if args.convergence_patience and no_improve >= args.convergence_patience:
+                print('>> Early stopping triggered')
+                logger.info('>> Early stopping triggered')
+                break


### PR DESCRIPTION
## Summary
- support AdamW as a DP-compatible optimizer option
- add early stopping with `--convergence_patience`/`--convergence_delta`
- document FedAvgM via `--server_momentum` and new optimizer and convergence flags

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a41024bcc0832a8f1e9c6a9f787b42