### PR TITLE
Enable layer-specific DP noise during server aggregation

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -780,8 +780,15 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
     return nets, epsilon
 
 
-def aggregate_deltas(global_w, deltas, args):
-    """Aggregate client deltas with clipping and noise."""
+def aggregate_deltas(global_w, deltas, args, noise_multipliers=None):
+    """Aggregate client deltas with clipping and layer-specific noise.
+
+    Args:
+        global_w (dict): Global model weights to be updated.
+        deltas (dict): Client updates keyed by client id.
+        args (Namespace): Training arguments.
+        noise_multipliers (dict, optional): Parameter-specific noise multipliers.
+    """
     clipped = []
     for delta in deltas.values():
         flat = torch.cat([v.view(-1) for v in delta.values()])
@@ -793,7 +800,10 @@ def aggregate_deltas(global_w, deltas, args):
             continue
         stacked = torch.stack([d[key] for d in clipped])
         avg_update = stacked.mean(dim=0)
-        noise = torch.randn_like(avg_update) * args.dp_noise * args.dp_clip
+        noise_mult = args.dp_noise
+        if noise_multipliers is not None:
+            noise_mult = noise_multipliers.get(key, args.dp_noise)
+        noise = torch.randn_like(avg_update) * noise_mult * args.dp_clip
         global_w[key] += avg_update + noise
 
 
@@ -997,7 +1007,11 @@ if __name__ == '__main__':
                 )
 
             if args.dp_mode == 'server':
-                aggregate_deltas(global_w, deltas, args)
+                noise_multipliers = {name: args.dp_noise for name in global_w}
+                for name in noise_multipliers:
+                    if name.endswith('bias'):
+                        noise_multipliers[name] *= 0.5
+                aggregate_deltas(global_w, deltas, args, noise_multipliers)
             else:
                 total_data_points = sum(len(net_dataidx_map[r]) for r in participating_ids)
                 fed_avg_freqs = [len(net_dataidx_map[r]) / total_data_points for r in participating_ids]


### PR DESCRIPTION
## Summary
- allow server aggregation to use per-parameter noise multipliers
- add layer-specific noise mapping that scales down bias noise

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a41a959938832ab27dff36593e6e82