### PR TITLE
Adapt DP clipping based on moving client gradient norms

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -719,6 +719,9 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
     indices_all_clients = []
     epsilon = None
     deltas = {}
+    if args.dp_mode == 'server' and not hasattr(args, 'client_grad_norms'):
+        args.client_grad_norms = {}
+    grad_ma_decay = 0.9
 
     for net_id, net in nets.items():
         print(net_id)
@@ -741,7 +744,12 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
             testacc = result
             if args.dp_mode == 'server':
                 new_params = net.state_dict()
-                deltas[net_id] = {k: new_params[k] - prev_params[k] for k in new_params}
+                delta = {k: new_params[k] - prev_params[k] for k in new_params}
+                deltas[net_id] = delta
+                flat = torch.cat([v.view(-1) for v in delta.values()])
+                norm = torch.norm(flat).item()
+                prev = args.client_grad_norms.get(net_id, norm)
+                args.client_grad_norms[net_id] = grad_ma_decay * prev + (1 - grad_ma_decay) * norm
         else:
             net.train()
             result, _ = train_net_few_shot_new(net_id, net, n_epoch, args.lr, args.optimizer, args, X_train_client, y_train_client, X_test, y_test,
@@ -1005,7 +1013,8 @@ if __name__ == '__main__':
                     accountant=args.dp_accountant,
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
-
+            if args.dp_mode == 'server' and getattr(args, 'client_grad_norms', None):
+                args.dp_clip = float(np.percentile(list(args.client_grad_norms.values()), 90))
             if args.dp_mode == 'server':
                 noise_multipliers = {name: args.dp_noise for name in global_w}
                 for name in noise_multipliers:

--- a/main_text.py
+++ b/main_text.py
@@ -708,6 +708,9 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
     indices_all_clients = []
     epsilon = None
     deltas = {}
+    if args.dp_mode == 'server' and not hasattr(args, 'client_grad_norms'):
+        args.client_grad_norms = {}
+    grad_ma_decay = 0.9
 
     for net_id, net in nets.items():
         print(net_id)
@@ -728,7 +731,12 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
             testacc = result
             if args.dp_mode == 'server':
                 new_params = net.state_dict()
-                deltas[net_id] = {k: new_params[k] - prev_params[k] for k in new_params}
+                delta = {k: new_params[k] - prev_params[k] for k in new_params}
+                deltas[net_id] = delta
+                flat = torch.cat([v.view(-1) for v in delta.values()])
+                norm = torch.norm(flat).item()
+                prev = args.client_grad_norms.get(net_id, norm)
+                args.client_grad_norms[net_id] = grad_ma_decay * prev + (1 - grad_ma_decay) * norm
         else:
             net.train()
             result, _ = train_net_few_shot_new(net_id, net, n_epoch, args.lr, args.optimizer, args, X_train_client, y_train_client, X_test, y_test,
@@ -987,7 +995,8 @@ if __name__ == '__main__':
                     accountant=args.dp_accountant,
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
-
+            if args.dp_mode == 'server' and getattr(args, 'client_grad_norms', None):
+                args.dp_clip = float(np.percentile(list(args.client_grad_norms.values()), 90))
             if args.dp_mode == 'server':
                 noise_multipliers = {name: args.dp_noise for name in global_w}
                 for name in noise_multipliers:


### PR DESCRIPTION
## Summary
- Track per-client gradient norms with exponential moving averages
- Recompute dp_clip as the moving 90th percentile before each DP step and use it for server-side clipping

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a42fe5b1dc832a935450a1ccdcdd28