### PR TITLE
Add gradient clipping and training logs to stabilise few-shot runs

### DIFF
--- a/main_text.py
+++ b/main_text.py
@@ -346,6 +346,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     for name, _ in dp_named_params:
         args.grad_norms_ma.setdefault(name, 0.0)
     grad_ma_decay = 0.9
+    max_norm = 5.0
     tl_optimizer = None
     if tl_params:
         tl_optimizer = optim.SGD(tl_params, lr=lr, momentum=0.9, weight_decay=args.reg)
@@ -559,6 +560,11 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                         loss_all += contras_loss / Q *0.1
                     loss_all += loss_ce(out_all, y_total)
                     loss_all.backward()
+                    grad_norm = torch.nn.utils.clip_grad_norm_(gmodel.parameters(), max_norm)
+                    loss_value = loss_all.item()
+                    print(f'batch loss: {loss_value:.4f}, grad_norm: {grad_norm:.4f}')
+                    if torch.isnan(torch.tensor(grad_norm)) or torch.isnan(loss_all.detach()):
+                        print('warning: NaN detected in loss or gradients')
                     if args.dp_mode == 'local':
                         for name, param in dp_named_params:
                             if param.grad is None:


### PR DESCRIPTION
## Summary
- clip gradients in `train_net_few_shot_new` for image and text models
- log per-batch loss and gradient norms while flagging NaNs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68a57e3e0e68832a8e395d1f66fc13af