### PR TITLE
Simplify DP configuration for image training

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Note that the text model requires the GloVe embedding file named 'glove.42B.300d
 The repository now includes optional support for a **personalised transformation layer** and **differential privacy** with a privacy accountant.
 
 * Enable the transformation layer with `--use_transform_layer 1`. Each client learns its own affine layer `T_k(x) = α ⊙ x + β` that is excluded from model aggregation.
-* Differential privacy is controlled via `--dp_mode`:
+* Differential privacy is controlled solely via `--dp_mode` (the deprecated `--use_dp` flag has been removed). DP-specific options are ignored when `--dp_mode off`:
   * `local` (default): apply DP-SGD on each client.
   * `server`: clip and noise client updates on the server.
   * `off`: disable differential privacy.

--- a/main_image.py
+++ b/main_image.py
@@ -194,7 +194,6 @@ def get_args():
                         help='minimum accuracy improvement to reset patience')
     parser.add_argument('--use_transform_layer', type=int, default=0,
                         help='enable personalized transformation layer')
-    parser.add_argument('--use_dp', type=int, default=0, help='enable DP-SGD')
     parser.add_argument('--dp_clip', type=float, default=1.0, help='DP-SGD clipping norm')
     parser.add_argument('--dp_noise', type=float, default=0.0, help='DP-SGD noise multiplier')
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
@@ -205,7 +204,6 @@ def get_args():
                         help='DP accountant to estimate the privacy budget')
     parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
     args = parser.parse_args()
-    args.use_dp = int(args.dp_mode != 'off')
     args.dp_clip = min(args.dp_clip, args.dp_clip_max)
     return args
 

--- a/model.py
+++ b/model.py
@@ -975,7 +975,7 @@ class ModelFed_Adp(nn.Module):
 
         encoder_layer = nn.TransformerEncoderLayer(d_model=num_ftrs, nhead=4, batch_first=True)
         transformer = nn.TransformerEncoder(encoder_layer=encoder_layer, num_layers=1)
-        if getattr(args, 'use_dp', 0):
+        if getattr(args, 'dp_mode', 'off') != 'off':
             self.transformer = ModuleValidator.fix(transformer)
             ModuleValidator.validate(self.transformer, strict=True)
         else:
@@ -1098,7 +1098,7 @@ class LSTMAtt(nn.Module):
 
         encoder_layer = nn.TransformerEncoderLayer(d_model=self.ebd_dim, nhead=4, batch_first=True)
         transformer = nn.TransformerEncoder(encoder_layer=encoder_layer, num_layers=1)
-        if getattr(args, 'use_dp', 0):
+        if getattr(args, 'dp_mode', 'off') != 'off':
             self.transformer = ModuleValidator.fix(transformer)
             ModuleValidator.validate(self.transformer, strict=True)
         else:


### PR DESCRIPTION
## Summary
- remove deprecated `--use_dp` flag from `main_image.py`
- gate transformer DP setup on `dp_mode` instead of `use_dp`
- document DP behaviour when `--dp_mode off`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a8198be2f4832a867ec2214e0e7aa5