### PR TITLE
Add server learning rate option for FedAvgM

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ python main_image.py --dataset miniImageNet --dp_mode local --dp_noise 0.2
 python main_image.py --dataset miniImageNet --dp_mode server --dp_noise 0.2
 # No DP
 python main_image.py --dataset miniImageNet --dp_mode off
+# FedAvgM with server learning rate
+python main_image.py --dataset miniImageNet --server_momentum 0.9 --server_lr 0.1
 ```
 When `--print_eps 1`, the current ε and δ are printed after each round.
 
-* Enable server momentum with `--server_momentum <m>` to use FedAvgM for faster convergence.
+* Enable server momentum with `--server_momentum <m>` and set the server learning rate with `--server_lr <lr>` to use FedAvgM for faster convergence. A good starting point is `lr ≈ 1 - m`.
 * Select DP-compatible optimizers via `--optimizer`. In addition to `sgd`, `adam`, and `amsgrad`, `adamw` is supported and becomes DP-AdamW when differential privacy is enabled.
 * Training can stop early when global accuracy plateaus. Set `--convergence_patience` and `--convergence_delta` to monitor convergence and exit before reaching the full `--comm_round`.
 

--- a/main_image.py
+++ b/main_image.py
@@ -188,6 +188,7 @@ def get_args():
     parser.add_argument('--save_model',type=int,default=0)
     parser.add_argument('--use_project_head', type=int, default=1)
     parser.add_argument('--server_momentum', type=float, default=0, help='the server momentum (FedAvgM)')
+    parser.add_argument('--server_lr', type=float, default=1.0, help='the server learning rate (FedAvgM)')
     parser.add_argument('--convergence_patience', type=int, default=0,
                         help='stop if accuracy does not improve after this many rounds (0 to disable)')
     parser.add_argument('--convergence_delta', type=float, default=0.0,
@@ -1124,7 +1125,7 @@ if __name__ == '__main__':
                 for key in delta_w:
                     delta_w[key] = old_w[key] - global_w[key]
                     moment_v[key] = args.server_momentum * moment_v[key] + (1-args.server_momentum) * delta_w[key]
-                    global_w[key] = old_w[key] - moment_v[key]
+                    global_w[key] = old_w[key] - args.server_lr * moment_v[key]
 
             global_model.load_state_dict(global_w)
 

--- a/main_text.py
+++ b/main_text.py
@@ -182,6 +182,7 @@ def get_args():
     parser.add_argument('--save_model',type=int,default=0)
     parser.add_argument('--use_project_head', type=int, default=1)
     parser.add_argument('--server_momentum', type=float, default=0, help='the server momentum (FedAvgM)')
+    parser.add_argument('--server_lr', type=float, default=1.0, help='the server learning rate (FedAvgM)')
     parser.add_argument('--convergence_patience', type=int, default=0,
                         help='stop if accuracy does not improve after this many rounds (0 to disable)')
     parser.add_argument('--convergence_delta', type=float, default=0.0,
@@ -1112,7 +1113,7 @@ if __name__ == '__main__':
                 for key in delta_w:
                     delta_w[key] = old_w[key] - global_w[key]
                     moment_v[key] = args.server_momentum * moment_v[key] + (1-args.server_momentum) * delta_w[key]
-                    global_w[key] = old_w[key] - moment_v[key]
+                    global_w[key] = old_w[key] - args.server_lr * moment_v[key]
 
             global_model.load_state_dict(global_w)
 


### PR DESCRIPTION
## Summary
- add `--server_lr` flag to text and image training scripts
- scale FedAvgM updates by `server_lr` for finer server optimization control
- document server learning rate usage and recommended relation to momentum

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68abe2263d78832a862ac48da77645e5