### PR TITLE
Add configurable LR schedulers for image training

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ python main_image.py --dataset miniImageNet --server_momentum 0.9 --server_lr 0.
 When `--print_eps 1`, the current ε and δ are printed after each round.
 
 * Enable server momentum with `--server_momentum <m>` and set the server learning rate with `--server_lr <lr>` to use FedAvgM for faster convergence. A good starting point is `lr ≈ 1 - m`.
+* Configure learning rate schedules with `--lr_schedule` and `--lr_decay`. Only `cosine` is currently supported. A suggested starting point is:
+
+    ```bash
+    python main_image.py --dataset miniImageNet --lr 0.001 --lr_schedule cosine --lr_decay 0.1
+    ```
+  This applies a cosine schedule that anneals the learning rate for both DP and head optimizers to 10% of its initial value.
 * Select DP-compatible optimizers via `--optimizer`. In addition to `sgd`, `adam`, and `amsgrad`, `adamw` is supported and becomes DP-AdamW when differential privacy is enabled.
 * Training can stop early when global accuracy plateaus. Set `--convergence_patience` and `--convergence_delta` to monitor convergence and exit before reaching the full `--comm_round`.
 


### PR DESCRIPTION
## Summary
- allow configuring LR schedulers via `--lr_schedule` and `--lr_decay`
- use `CosineAnnealingLR` for DP and head optimizers in few-shot image training
- step schedulers after each training and validation epoch
- document scheduler usage in README with starter parameters

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac0c651c88832a9d41fa4079ec13f2