### PR TITLE
Maintain DP noise-to-clip ratio and log z

### DIFF
--- a/dp_utils.py
+++ b/dp_utils.py
@@ -93,6 +93,29 @@ def compute_epsilon(num_steps, noise_mult, delta, accountant=None, sampling_rate
     return math.sqrt(2 * num_steps * math.log(1 / delta)) / noise_mult
 
 
+def scale_noise_to_clip(noise_mult, old_clip, new_clip):
+    """Return a noise multiplier keeping the noise-to-clip ratio fixed.
+
+    Parameters
+    ----------
+    noise_mult : float
+        Current noise multiplier.
+    old_clip : float
+        Previous clipping bound.
+    new_clip : float
+        Updated clipping bound.
+
+    Returns
+    -------
+    float
+        Noise multiplier rescaled so that ``noise_mult / old_clip`` equals
+        ``new_noise / new_clip``.
+    """
+    if old_clip == 0:
+        raise ValueError('old_clip must be non-zero')
+    return (noise_mult / old_clip) * new_clip
+
+
 def find_noise_multiplier(
     num_steps,
     target_eps,

--- a/main_image.py
+++ b/main_image.py
@@ -1147,11 +1147,14 @@ if __name__ == '__main__':
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
             if args.dp_mode == 'server' and getattr(args, 'client_grad_norms', None):
+                old_clip = args.dp_clip
                 new_clip = float(np.percentile(list(args.client_grad_norms.values()), 90))
                 adjusted_clip = min(new_clip, args.dp_clip_max)
                 args.dp_clip = 0.9 * args.dp_clip + 0.1 * adjusted_clip
-                print(f'90th percentile: {new_clip:.4f}, DP clip: {args.dp_clip:.4f}')
-                logger.info('90th percentile %.4f, DP clip %.4f', new_clip, args.dp_clip)
+                args.dp_noise = dp_utils.scale_noise_to_clip(args.dp_noise, old_clip, args.dp_clip)
+                z = args.dp_noise / args.dp_clip
+                print(f'90th percentile: {new_clip:.4f}, DP clip: {args.dp_clip:.4f}, z: {z:.4f}')
+                logger.info('90th percentile %.4f, DP clip %.4f, z %.4f', new_clip, args.dp_clip, z)
             if args.dp_mode == 'server':
                 noise_multipliers = {name: args.dp_noise for name in global_w}
                 for name in noise_multipliers:


### PR DESCRIPTION
## Summary
- add `scale_noise_to_clip` helper to rescale DP noise when the clip bound changes
- recompute server-side DP noise after dynamic clip adjustment and log resulting `z`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ad6457a718832abfa4a103c61b5103