### PR TITLE
Track clipped clients for adaptive DP clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The repository now includes optional support for a **personalised transformation
   * `--dp_noise`: noise multiplier
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)
   * `--print_eps`: output the current ε after each communication round when set to `1`
+  * `--dp_target_clip_fraction`: desired fraction of client updates to clip (default `0.1`)
 
 Examples:
 

--- a/main_image.py
+++ b/main_image.py
@@ -203,6 +203,8 @@ def get_args():
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_clip_max', type=float, default=20.0, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
+                        help='target fraction of clients to be clipped')
     parser.add_argument('--dp_mode', choices=['local', 'server', 'off'], default='server')
     parser.add_argument('--dp_accountant', choices=['rdp', 'prv'], default='rdp',
                         help='DP accountant to estimate the privacy budget')
@@ -878,7 +880,9 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
     """Aggregate client deltas with clipping and layer-specific noise.
 
     Noise is scaled by the number of participating clients to maintain the
-    expected privacy budget regardless of the number of contributions.
+    expected privacy budget regardless of the number of contributions. The
+    fraction of client updates that were clipped is stored in
+    ``args.last_clip_fraction`` for adaptive clipping strategies.
 
     Args:
         global_w (dict): Global model weights to be updated.
@@ -910,6 +914,8 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
         scales.append(scale)
         clipped.append({k: v * scale for k, v in delta.items() if 'few_classify' not in k and 'transform_layer' not in k})
     num_clients = len(clipped) or 1
+    args.last_clip_fraction = float(np.mean([s < 1.0 for s in scales])) if scales else 0.0
+    logging.info('Clipped fraction: %.4f', args.last_clip_fraction)
     if scales:
         logging.info('Clipping scale stats - mean: %.4f max: %.4f', float(np.mean(scales)), float(np.max(scales)))
     base_noise_std = args.dp_noise * args.dp_noise_scale * args.dp_clip / num_clients
@@ -1082,6 +1088,12 @@ if __name__ == '__main__':
             #logger.info("in comm round:" + str(round))
             party_list_this_round = party_list_rounds[round]
 
+            if args.dp_mode == 'server' and getattr(args, 'last_clip_fraction', None) is not None:
+                if args.last_clip_fraction < args.dp_target_clip_fraction:
+                    old_clip = args.dp_clip
+                    args.dp_clip *= 0.9
+                    args.dp_noise = dp_utils.scale_noise_to_clip(args.dp_noise, old_clip, args.dp_clip)
+
             global_w = global_model.state_dict()
             if args.server_momentum:
                 old_w = copy.deepcopy(global_model.state_dict())
@@ -1150,8 +1162,10 @@ if __name__ == '__main__':
                 old_clip = args.dp_clip
                 new_clip = float(np.percentile(list(args.client_grad_norms.values()), 90))
                 adjusted_clip = min(new_clip, args.dp_clip_max)
-                args.dp_clip = 0.9 * args.dp_clip + 0.1 * adjusted_clip
-                args.dp_noise = dp_utils.scale_noise_to_clip(args.dp_noise, old_clip, args.dp_clip)
+                lower, upper = 0.8 * adjusted_clip, adjusted_clip
+                args.dp_clip = max(lower, min(args.dp_clip, upper))
+                if args.dp_clip != old_clip:
+                    args.dp_noise = dp_utils.scale_noise_to_clip(args.dp_noise, old_clip, args.dp_clip)
                 z = args.dp_noise / args.dp_clip
                 print(f'90th percentile: {new_clip:.4f}, DP clip: {args.dp_clip:.4f}, z: {z:.4f}')
                 logger.info('90th percentile %.4f, DP clip %.4f, z %.4f', new_clip, args.dp_clip, z)

--- a/main_text.py
+++ b/main_text.py
@@ -196,6 +196,8 @@ def get_args():
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_clip_max', type=float, default=2.0, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
+                        help='target fraction of clients to be clipped')
     parser.add_argument('--dp_mode', choices=['local', 'server', 'off'], default='server')
     parser.add_argument('--dp_accountant', choices=['rdp', 'prv'], default='rdp',
                         help='DP accountant to estimate the privacy budget')
@@ -851,7 +853,9 @@ def aggregate_deltas(
 
     Noise is scaled by the number of participating clients. When
     ``noise_multipliers`` is provided, parameter-specific multipliers are applied
-    on top of the base noise multiplier ``args.dp_noise``.
+    on top of the base noise multiplier ``args.dp_noise``. The fraction of
+    client updates that were clipped is stored in
+    ``args.last_clip_fraction`` for adaptive clipping strategies.
 
     Args:
         global_w (dict): Global model weights to be updated.
@@ -861,6 +865,7 @@ def aggregate_deltas(
         reset_bn (bool, optional): Reset BatchNorm statistics after aggregation.
     """
     clipped = []
+    clipped_count = 0
     for delta in deltas.values():
         flat = torch.cat([
             v.view(-1)
@@ -878,8 +883,12 @@ def aggregate_deltas(
         ])
         norm = torch.norm(flat)
         scale = min(1.0, args.dp_clip / (norm + 1e-12))
+        if scale < 1.0:
+            clipped_count += 1
         clipped.append({k: v * scale for k, v in delta.items() if 'few_classify' not in k and 'transform_layer' not in k})
     num_clients = len(clipped) or 1
+    args.last_clip_fraction = clipped_count / num_clients
+    logging.info('Clipped fraction: %.4f', args.last_clip_fraction)
     base_noise_std = args.dp_noise * args.dp_noise_scale * args.dp_clip / num_clients
     logging.info('Effective noise std: %.6f (clients=%d)', base_noise_std, num_clients)
     for key in global_w:
@@ -1048,6 +1057,12 @@ if __name__ == '__main__':
             #logger.info("in comm round:" + str(round))
             party_list_this_round = party_list_rounds[round]
 
+            if args.dp_mode == 'server' and getattr(args, 'last_clip_fraction', None) is not None:
+                if args.last_clip_fraction < args.dp_target_clip_fraction:
+                    old_clip = args.dp_clip
+                    args.dp_clip *= 0.9
+                    args.dp_noise = dp_utils.scale_noise_to_clip(args.dp_noise, old_clip, args.dp_clip)
+
             global_w = global_model.state_dict()
             if args.server_momentum:
                 old_w = copy.deepcopy(global_model.state_dict())
@@ -1114,7 +1129,11 @@ if __name__ == '__main__':
             if args.dp_mode == 'server' and getattr(args, 'client_grad_norms', None):
                 new_clip = float(np.percentile(list(args.client_grad_norms.values()), 90))
                 adjusted_clip = min(new_clip, args.dp_clip_max)
-                args.dp_clip = 0.9 * args.dp_clip + 0.1 * adjusted_clip
+                lower, upper = 0.8 * adjusted_clip, adjusted_clip
+                old_clip = args.dp_clip
+                args.dp_clip = max(lower, min(args.dp_clip, upper))
+                if args.dp_clip != old_clip:
+                    args.dp_noise = dp_utils.scale_noise_to_clip(args.dp_noise, old_clip, args.dp_clip)
                 print(f'90th percentile: {new_clip:.4f}, DP clip: {args.dp_clip:.4f}')
                 logger.info('90th percentile %.4f, DP clip %.4f', new_clip, args.dp_clip)
             if args.dp_mode == 'server':


### PR DESCRIPTION
## Summary
- adapt DP clipping to stay within 80-100% of recent norm percentile
- record fraction of clients clipped and reduce dp_clip when too few are clipped
- expose `--dp_target_clip_fraction` to tune desired clipping rate

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ad66cedb34832ab170ad3ea5d17ad0