### PR TITLE
Use log-scale EMA for DP clip adaptation

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -11,6 +11,7 @@ import copy
 import datetime
 import random
 import time
+import math
 
 from PIL import Image
 
@@ -1087,10 +1088,6 @@ if __name__ == '__main__':
             #logger.info("in comm round:" + str(round))
             party_list_this_round = party_list_rounds[round]
 
-            if args.dp_mode == 'server' and getattr(args, 'last_clip_fraction', None) is not None:
-                if args.last_clip_fraction < args.dp_target_clip_fraction:
-                    args.dp_clip *= 0.9
-
             global_w = global_model.state_dict()
             if args.server_momentum:
                 old_w = copy.deepcopy(global_model.state_dict())
@@ -1157,9 +1154,14 @@ if __name__ == '__main__':
                 )
             if args.dp_mode == 'server' and getattr(args, 'client_grad_norms', None):
                 new_clip = float(np.percentile(list(args.client_grad_norms.values()), 90))
-                adjusted_clip = min(new_clip, args.dp_clip_max)
-                lower, upper = 0.8 * adjusted_clip, adjusted_clip
-                args.dp_clip = max(lower, min(args.dp_clip, upper))
+                clipped_clip = max(1.0, min(new_clip, args.dp_clip_max))
+                if not hasattr(args, 'log_dp_clip'):
+                    args.log_dp_clip = math.log(max(1.0, args.dp_clip))
+                eta = 0.4
+                args.log_dp_clip += eta * (math.log(clipped_clip) - args.log_dp_clip)
+                args.dp_clip = float(math.exp(args.log_dp_clip))
+                args.dp_clip = max(1.0, min(args.dp_clip, args.dp_clip_max))
+
                 num_clients = len(deltas) or 1
                 z = args.dp_noise * args.dp_noise_scale / num_clients
                 print(f'90th percentile: {new_clip:.4f}, DP clip: {args.dp_clip:.4f}, z: {z:.4f}')

--- a/main_text.py
+++ b/main_text.py
@@ -11,6 +11,7 @@ import copy
 import datetime
 import random
 import time
+import math
 
 from PIL import Image
 
@@ -1056,9 +1057,6 @@ if __name__ == '__main__':
             #logger.info("in comm round:" + str(round))
             party_list_this_round = party_list_rounds[round]
 
-            if args.dp_mode == 'server' and getattr(args, 'last_clip_fraction', None) is not None:
-                if args.last_clip_fraction < args.dp_target_clip_fraction:
-                    args.dp_clip *= 0.9
 
             global_w = global_model.state_dict()
             if args.server_momentum:
@@ -1125,9 +1123,13 @@ if __name__ == '__main__':
                 )
             if args.dp_mode == 'server' and getattr(args, 'client_grad_norms', None):
                 new_clip = float(np.percentile(list(args.client_grad_norms.values()), 90))
-                adjusted_clip = min(new_clip, args.dp_clip_max)
-                lower, upper = 0.8 * adjusted_clip, adjusted_clip
-                args.dp_clip = max(lower, min(args.dp_clip, upper))
+                clipped_clip = max(1.0, min(new_clip, args.dp_clip_max))
+                if not hasattr(args, 'log_dp_clip'):
+                    args.log_dp_clip = math.log(max(1.0, args.dp_clip))
+                eta = 0.4
+                args.log_dp_clip += eta * (math.log(clipped_clip) - args.log_dp_clip)
+                args.dp_clip = float(math.exp(args.log_dp_clip))
+                args.dp_clip = max(1.0, min(args.dp_clip, args.dp_clip_max))
                 num_clients = len(deltas) or 1
                 z = args.dp_noise * args.dp_noise_scale / num_clients
                 print(f'90th percentile: {new_clip:.4f}, DP clip: {args.dp_clip:.4f}, z: {z:.4f}')


### PR DESCRIPTION
## Summary
- Remove one-sided DP clip reduction based on last_clip_fraction in training loops
- Apply log-scale exponential moving average to update `dp_clip` and store its log state for reuse
- Clamp `dp_clip` to `[1.0, dp_clip_max]` and add `math` dependency in image and text main scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ad91bb3b2c832a9c8c964b312bddb2