### PR TITLE
Add z-based DP noise scaling

### DIFF
--- a/dp_utils.py
+++ b/dp_utils.py
@@ -93,6 +93,28 @@ def compute_epsilon(num_steps, noise_mult, delta, accountant=None, sampling_rate
     return math.sqrt(2 * num_steps * math.log(1 / delta)) / noise_mult
 
 
+def noise_multiplier_for_z(z, clip, num_clients, scale):
+    """Return a noise multiplier for a desired ``z`` value.
+
+    Parameters
+    ----------
+    z : float
+        Target ratio of noise standard deviation to the clipping norm.
+    clip : float
+        Clipping bound applied to client updates.
+    num_clients : int
+        Number of participating clients.
+    scale : float
+        Additional scaling applied to the noise.
+
+    Returns
+    -------
+    float
+        Noise multiplier producing the requested ``z``.
+    """
+    return z * clip * num_clients / scale
+
+
 def scale_noise_to_clip(noise_mult, old_clip, new_clip):
     """Return a noise multiplier keeping the noise-to-clip ratio fixed.
 

--- a/main_image.py
+++ b/main_image.py
@@ -207,6 +207,7 @@ def get_args():
     parser.add_argument('--dp_clip', type=float, default=1.0, help='DP-SGD clipping norm')
     parser.add_argument('--dp_noise', type=float, default=0.0, help='DP-SGD noise multiplier')
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
+    parser.add_argument('--dp_z', type=float, default=0.2, help='target noise-to-clip ratio')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_clip_max', type=float, default=20.0, help='maximum DP-SGD clipping norm')
     parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
@@ -1211,11 +1212,12 @@ if __name__ == '__main__':
             if args.dp_mode == 'server':
                 if round == 0:
                     new_clip = float(np.percentile(list(args.client_grad_norms.values()), 85))
-                    old_clip = args.dp_clip
                     args.dp_clip = min(new_clip, args.dp_clip_max)
                     args.log_dp_clip = math.log(args.dp_clip)
-                    args.dp_noise = dp_utils.scale_noise_to_clip(args.dp_noise, old_clip, args.dp_clip)
-                old_clip, old_noise = args.dp_clip, args.dp_noise
+                    args.dp_noise = dp_utils.noise_multiplier_for_z(
+                        args.dp_z, args.dp_clip, len(deltas), args.dp_noise_scale
+                    )
+                old_clip = args.dp_clip
                 decay = 0.9
                 num_clients = len(deltas) or 1
                 if num_clients * args.dp_target_clip_fraction < 1:
@@ -1232,11 +1234,18 @@ if __name__ == '__main__':
                 new_clip = max(min(new_clip, old_clip * 1.15), old_clip * 0.85)
                 args.dp_clip = max(1.0, min(new_clip, args.dp_clip_max))
                 args.log_dp_clip = math.log(args.dp_clip)
-                args.dp_noise = dp_utils.scale_noise_to_clip(old_noise, old_clip, args.dp_clip)
-                noise_std = args.dp_noise * args.dp_noise_scale / num_clients
-                z = noise_std / args.dp_clip
-                print(f'clip EMA: {args.clip_frac_ema:.4f}, DP clip: {args.dp_clip:.4f}, z: {z:.4f}')
-                logger.info('clip EMA %.4f, DP clip %.4f, z %.4f', args.clip_frac_ema, args.dp_clip, z)
+                args.dp_noise = dp_utils.noise_multiplier_for_z(
+                    args.dp_z, args.dp_clip, len(deltas), args.dp_noise_scale
+                )
+                print(
+                    f'clip EMA: {args.clip_frac_ema:.4f}, DP clip: {args.dp_clip:.4f}, z: {args.dp_z:.4f}'
+                )
+                logger.info(
+                    'clip EMA %.4f, DP clip %.4f, z %.4f',
+                    args.clip_frac_ema,
+                    args.dp_clip,
+                    args.dp_z,
+                )
             if hasattr(args, 'mean_clip_scale'):
                 if not hasattr(args, 'base_server_lr'):
                     args.base_server_lr = args.server_lr

--- a/main_text.py
+++ b/main_text.py
@@ -200,6 +200,7 @@ def get_args():
     parser.add_argument('--dp_clip', type=float, default=1.0, help='DP-SGD clipping norm')
     parser.add_argument('--dp_noise', type=float, default=0.0, help='DP-SGD noise multiplier')
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
+    parser.add_argument('--dp_z', type=float, default=0.2, help='target noise-to-clip ratio')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_clip_max', type=float, default=2.0, help='maximum DP-SGD clipping norm')
     parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
@@ -1180,11 +1181,12 @@ if __name__ == '__main__':
             if args.dp_mode == 'server':
                 if round == 0:
                     new_clip = float(np.percentile(list(args.client_grad_norms.values()), 85))
-                    old_clip = args.dp_clip
                     args.dp_clip = min(new_clip, args.dp_clip_max)
                     args.log_dp_clip = math.log(args.dp_clip)
-                    args.dp_noise = dp_utils.scale_noise_to_clip(args.dp_noise, old_clip, args.dp_clip)
-                old_clip, old_noise = args.dp_clip, args.dp_noise
+                    args.dp_noise = dp_utils.noise_multiplier_for_z(
+                        args.dp_z, args.dp_clip, len(deltas), args.dp_noise_scale
+                    )
+                old_clip = args.dp_clip
                 decay = 0.9
                 num_clients = len(deltas) or 1
                 if num_clients * args.dp_target_clip_fraction < 1:
@@ -1201,11 +1203,18 @@ if __name__ == '__main__':
                 new_clip = max(min(new_clip, old_clip * 1.15), old_clip * 0.85)
                 args.dp_clip = max(1.0, min(new_clip, args.dp_clip_max))
                 args.log_dp_clip = math.log(args.dp_clip)
-                args.dp_noise = dp_utils.scale_noise_to_clip(old_noise, old_clip, args.dp_clip)
-                noise_std = args.dp_noise * args.dp_noise_scale / num_clients
-                z = noise_std / args.dp_clip
-                print(f'clip EMA: {args.clip_frac_ema:.4f}, DP clip: {args.dp_clip:.4f}, z: {z:.4f}')
-                logger.info('clip EMA %.4f, DP clip %.4f, z %.4f', args.clip_frac_ema, args.dp_clip, z)
+                args.dp_noise = dp_utils.noise_multiplier_for_z(
+                    args.dp_z, args.dp_clip, len(deltas), args.dp_noise_scale
+                )
+                print(
+                    f'clip EMA: {args.clip_frac_ema:.4f}, DP clip: {args.dp_clip:.4f}, z: {args.dp_z:.4f}'
+                )
+                logger.info(
+                    'clip EMA %.4f, DP clip %.4f, z %.4f',
+                    args.clip_frac_ema,
+                    args.dp_clip,
+                    args.dp_z,
+                )
             if hasattr(args, 'mean_clip_scale'):
                 if not hasattr(args, 'base_server_lr'):
                     args.base_server_lr = args.server_lr


### PR DESCRIPTION
## Summary
- add `noise_multiplier_for_z` helper to derive noise multipliers from a target z
- expose new `--dp_z` option for setting the desired noise-to-clip ratio
- compute DP noise multipliers from z after adaptive clipping and log the chosen z

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aeb7ba5aac832a8a40fe6d11e0d7f7