### PR TITLE
Calibrate DP clipping via warm-up gradient norms

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The repository now includes optional support for a **personalised transformation
   * `--dp_noise`: noise multiplier
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)
   * `--print_eps`: output the current ε after each communication round when set to `1`
+  * `--dp_warmup_batches`: run this many unclipped batches to calibrate `dp_clip` (90th percentile of gradient norms)
   * `--dp_target_clip_fraction`: desired fraction of client updates to clip (default `0.1`)
 
 Examples:
@@ -64,6 +65,9 @@ python main_image.py --dataset miniImageNet --dp_mode off
 python main_image.py --dataset miniImageNet --server_momentum 0.9 --server_lr 0.1
 ```
 When `--print_eps 1`, the current ε and δ are printed after each round.
+
+The scripts can optionally calibrate the initial clipping bound. When `--dp_warmup_batches` is greater than zero, a short warm-up
+phase runs without clipping, collects gradient norms, and sets `--dp_clip` to their 90th percentile before enabling DP-SGD.
 
 * Enable server momentum with `--server_momentum <m>` and set the server learning rate with `--server_lr <lr>` to use FedAvgM for faster convergence. A good starting point is `lr ≈ 1 - m`.
 * Configure learning rate schedules with `--lr_schedule` and `--lr_decay`. Only `cosine` is currently supported. A suggested starting point is:

--- a/main_image.py
+++ b/main_image.py
@@ -113,6 +113,23 @@ def InforNCE_Loss(anchor, sample, tau, all_negative=False, temperature_matrix=No
 
     return -loss.mean(), sim
 
+
+def collect_grad_norms(model, data_loader, optimizer, steps, device):
+    '''Collect gradient norms over a number of warm-up batches without clipping.'''
+    norms = []
+    model.train()
+    for i, (x, y) in enumerate(data_loader):
+        if i >= steps:
+            break
+        x, y = x.to(device), y.to(device)
+        optimizer.zero_grad()
+        out = model(x)
+        loss = F.cross_entropy(out, y)
+        loss.backward()
+        norm = torch.nn.utils.clip_grad_norm_(model.parameters(), float('inf'))
+        norms.append(norm.item())
+    return norms
+
 def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--model', type=str, default='resnet12', help='neural network used in training')
@@ -209,6 +226,7 @@ def get_args():
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_clip_max', type=float, default=20.0, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--dp_warmup_batches', type=int, default=0, help='warm-up batches for DP clip calibration')
     parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
                         help='target fraction of clients to be clipped')
     parser.add_argument('--dp_mode', choices=['local', 'server', 'off'], default='server')
@@ -337,6 +355,23 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     N, K, Q = get_n_k_q(args, mode='train', fewrel_multiplier=3)
     total_batch = N * K + N * Q
     sample_rate = total_batch / client_sample_size
+
+    if args.dp_mode == 'local' and args.dp_warmup_batches > 0 and dp_params and not getattr(args, 'dp_clip_calibrated', False):
+        warm_loader = DataLoader(
+            TensorDataset(torch.tensor(X_train_client), torch.tensor(y_train_client)),
+            batch_size=total_batch,
+            shuffle=True,
+        )
+        norms = collect_grad_norms(base_model, warm_loader, dp_optimizer, args.dp_warmup_batches, args.device)
+        if norms:
+            new_clip = float(np.percentile(norms, 90))
+            args.dp_clip = min(new_clip, args.dp_clip_max)
+            args.log_dp_clip = math.log(max(1.0, args.dp_clip))
+            args.dp_clip_calibrated = True
+            print(f'warm-up DP clip: {args.dp_clip:.4f}')
+        base_model.load_state_dict(model_template.state_dict())
+        dp_optimizer.zero_grad()
+        head_optimizer.zero_grad()
 
     privacy_engine = None
     if args.dp_mode == 'local' and dp_params:

--- a/main_text.py
+++ b/main_text.py
@@ -104,6 +104,23 @@ def InforNCE_Loss(anchor, sample, tau, all_negative=False, temperature_matrix=No
     loss = loss.sum(dim=1) / pos_mask.sum(dim=1)
 
     return -loss.mean(), sim
+
+
+def collect_grad_norms(model, data_loader, optimizer, steps, device):
+    '''Collect gradient norms over a number of warm-up batches without clipping.'''
+    norms = []
+    model.train()
+    for i, (x, y) in enumerate(data_loader):
+        if i >= steps:
+            break
+        x, y = x.to(device), y.to(device)
+        optimizer.zero_grad()
+        out = model(x)
+        loss = F.cross_entropy(out, y)
+        loss.backward()
+        norm = torch.nn.utils.clip_grad_norm_(model.parameters(), float('inf'))
+        norms.append(norm.item())
+    return norms
         
         
 def get_args():
@@ -202,6 +219,7 @@ def get_args():
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_clip_max', type=float, default=2.0, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--dp_warmup_batches', type=int, default=0, help='warm-up batches for DP clip calibration')
     parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
                         help='target fraction of clients to be clipped')
     parser.add_argument('--dp_mode', choices=['local', 'server', 'off'], default='server')
@@ -331,6 +349,23 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     N, K, Q = get_n_k_q(args, mode='train')
     total_batch = N * K + N * Q
     sample_rate = total_batch / client_sample_size
+
+    if args.dp_mode == 'local' and args.dp_warmup_batches > 0 and dp_params and not getattr(args, 'dp_clip_calibrated', False):
+        warm_loader = DataLoader(
+            TensorDataset(torch.tensor(X_train_client), torch.tensor(y_train_client)),
+            batch_size=total_batch,
+            shuffle=True,
+        )
+        norms = collect_grad_norms(base_model, warm_loader, dp_optimizer, args.dp_warmup_batches, args.device)
+        if norms:
+            new_clip = float(np.percentile(norms, 90))
+            args.dp_clip = min(new_clip, args.dp_clip_max)
+            args.log_dp_clip = math.log(max(1.0, args.dp_clip))
+            args.dp_clip_calibrated = True
+            print(f'warm-up DP clip: {args.dp_clip:.4f}')
+        base_model.load_state_dict(model_template.state_dict())
+        dp_optimizer.zero_grad()
+        head_optimizer.zero_grad()
 
     privacy_engine = None
     if args.dp_mode == 'local' and dp_params:


### PR DESCRIPTION
## Summary
- add warm-up routine that collects gradient norms without clipping
- set initial `dp_clip` to 90th-percentile of warm-up norms and expose `--dp_warmup_batches`
- document DP clip calibration in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b00a9131cc832ab9f51f169fb2e688