### PR TITLE
Implement stabilized adaptive DP clipping with fixed noise

### DIFF
--- a/dp_utils.py
+++ b/dp_utils.py
@@ -1,5 +1,10 @@
 import math
-from opacus.grad_sample import GradSampleModule
+import numpy as np
+try:
+    from opacus.grad_sample import GradSampleModule
+except Exception:  # pragma: no cover - fallback when opacus is absent
+    class GradSampleModule:  # type: ignore
+        pass
 
 
 def remove_dp_hooks(model):
@@ -173,3 +178,121 @@ def find_noise_multiplier(
         if abs(eps - target_eps) <= tol:
             break
     return hi
+
+
+def weighted_median(values, weights=None):
+    """Return the weighted median of ``values``.
+
+    Parameters
+    ----------
+    values : list[float]
+        Data values.
+    weights : list[float], optional
+        Corresponding non-negative weights. If ``None`` all weights are equal.
+
+    Returns
+    -------
+    float
+        Weighted median.
+    """
+    if not values:
+        raise ValueError('values must be non-empty')
+    if weights is None:
+        weights = [1.0] * len(values)
+    sorted_pairs = sorted(zip(values, weights), key=lambda x: x[0])
+    values, weights = zip(*sorted_pairs)
+    cum_weights = np.cumsum(weights)
+    threshold = 0.5 * cum_weights[-1]
+    idx = int(np.searchsorted(cum_weights, threshold, side='left'))
+    return float(values[idx])
+
+
+def initial_clip(p90s, weights=None, min_clip=1.2, max_clip=5.0):
+    """Compute the initial clipping bound from client percentiles."""
+    clip = weighted_median(p90s, weights)
+    return float(max(min_clip, min(clip, max_clip)))
+
+
+class AdaptiveClipper:
+    """Adaptive clipping controller with percentile blending.
+
+    The controller adjusts the clipping bound to keep the fraction of clipped
+    client updates close to a target level while incorporating percentile
+    information from gradient norms. Noise is assumed to remain fixed.
+    """
+
+    def __init__(
+        self,
+        clip,
+        target=0.2,
+        beta=0.95,
+        kp=0.05,
+        gamma=0.1,
+        alpha=0.5,
+        min_clip=1.2,
+        max_clip=5.0,
+    ):
+        self.clip = clip
+        self.target = target
+        self.beta = beta
+        self.kp = kp
+        self.gamma = gamma
+        self.alpha = alpha
+        self.min_clip = min_clip
+        self.max_clip = max_clip
+        self.clip_frac_ema = target
+        self._deadband = 0.05
+        self._steady_rounds = 0
+        self._high_ctr = 0
+        self._low_ctr = 0
+
+    def update(self, clipped_fraction, q90):
+        """Update the clipping bound.
+
+        Parameters
+        ----------
+        clipped_fraction : float
+            Fraction of client updates that were clipped this round.
+        q90 : float
+            90th percentile of pre-clip gradient norms across clients.
+
+        Returns
+        -------
+        float
+            Updated clipping bound.
+        """
+        self.clip_frac_ema = self.beta * self.clip_frac_ema + (1 - self.beta) * clipped_fraction
+        if abs(self.clip_frac_ema - self.target) <= self._deadband:
+            self._steady_rounds += 1
+        else:
+            self._steady_rounds = 0
+        if self._steady_rounds >= 3:
+            return self.clip
+
+        log_c = math.log(self.clip)
+        log_c_prime = log_c + self.kp * (self.clip_frac_ema - self.target)
+        log_c_tilde = (1 - self.gamma) * log_c + self.gamma * math.log(max(q90, 1e-12))
+        log_c_new = (1 - self.alpha) * log_c_prime + self.alpha * log_c_tilde
+        c_new = float(math.exp(log_c_new))
+        c_new = max(min(c_new, self.clip * 1.1), self.clip * 0.9)
+        c_new = max(self.min_clip, min(c_new, self.max_clip))
+        self.clip = c_new
+
+        if clipped_fraction > 0.5:
+            self._high_ctr += 1
+            self._low_ctr = 0
+        elif clipped_fraction < 0.05:
+            self._low_ctr += 1
+            self._high_ctr = 0
+        else:
+            self._high_ctr = 0
+            self._low_ctr = 0
+
+        if self._high_ctr >= 5:
+            self.clip = min(self.clip * 1.12, self.max_clip)
+            self._high_ctr = 0
+        if self._low_ctr >= 5:
+            self.clip = max(self.clip * 0.88, self.min_clip)
+            self._low_ctr = 0
+
+        return self.clip

--- a/main_image.py
+++ b/main_image.py
@@ -368,12 +368,34 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         if norms:
             new_clip = float(np.percentile(norms, 90))
             args.dp_clip = min(new_clip, args.dp_clip_max)
-            args.log_dp_clip = math.log(max(1.0, args.dp_clip))
             args.dp_clip_calibrated = True
             print(f'warm-up DP clip: {args.dp_clip:.4f}')
         base_model.load_state_dict(model_template.state_dict())
         dp_optimizer.zero_grad()
         head_optimizer.zero_grad()
+
+    if args.dp_mode == 'server' and args.dp_warmup_batches > 0 and not getattr(args, 'dp_clip_calibrated', False):
+        p90s, weights = [], []
+        for net_id in range(args.n_parties):
+            dataidxs = net_dataidx_map[net_id]
+            X_train_client = X_train[dataidxs]
+            y_train_client = y_train[dataidxs]
+            warm_loader = DataLoader(
+                TensorDataset(torch.tensor(X_train_client), torch.tensor(y_train_client)),
+                batch_size=total_batch,
+                shuffle=True,
+            )
+            tmp_model = copy.deepcopy(global_model)
+            warm_opt = optim.SGD(tmp_model.parameters(), lr=args.lr)
+            norms = collect_grad_norms(tmp_model, warm_loader, warm_opt, args.dp_warmup_batches, args.device)
+            if norms:
+                p90s.append(float(np.percentile(norms, 90)))
+                weights.append(len(y_train_client))
+        if p90s:
+            args.dp_clip = dp_utils.initial_clip(p90s, weights, max_clip=args.dp_clip_max)
+            args.dp_clip_calibrated = True
+            print(f'warm-up DP clip: {args.dp_clip:.4f}')
+        args.clipper = dp_utils.AdaptiveClipper(args.dp_clip, max_clip=args.dp_clip_max)
 
     privacy_engine = None
     if args.dp_mode == 'local' and dp_params:
@@ -961,6 +983,7 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
     """
     clipped = []
     scales = []
+    norms = []
     for cid, delta in deltas.items():
         flat = torch.cat([
             v.view(-1)
@@ -977,6 +1000,7 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
             )
         ])
         norm = torch.norm(flat).item()
+        norms.append(norm)
         scale = min(1.0, args.dp_clip / (norm + 1e-12))
         logging.info('Client %s norm %.4f scale %.4f', cid, norm, scale)
         scales.append(scale)
@@ -984,6 +1008,11 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
     num_clients = len(clipped) or 1
     args.last_clip_fraction = float(np.mean([s < 1.0 for s in scales])) if scales else 0.0
     logging.info('Clipped fraction: %.4f', args.last_clip_fraction)
+    if norms:
+        args.q0_9 = float(np.percentile(norms, 90))
+    else:
+        args.q0_9 = args.dp_clip
+    logging.info('q0.9 norm: %.4f', args.q0_9)
     if scales:
         logging.info('Clipping scale stats - mean: %.4f max: %.4f', float(np.mean(scales)), float(np.max(scales)))
     base_noise_std = args.dp_noise * args.dp_noise_scale / num_clients
@@ -1244,32 +1273,23 @@ if __name__ == '__main__':
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
             if args.dp_mode == 'server':
-                old_clip, old_noise = args.dp_clip, args.dp_noise
-                decay = 0.9
-                if not hasattr(args, 'last_clip_fraction'):
-                    args.last_clip_fraction = args.dp_target_clip_fraction
-                if not hasattr(args, 'clip_frac_ema'):
-                    args.clip_frac_ema = args.last_clip_fraction
-                else:
-                    args.clip_frac_ema = decay * args.clip_frac_ema + (1 - decay) * args.last_clip_fraction
-                eta = 0.1
-                args.log_dp_clip += eta * (args.clip_frac_ema - args.dp_target_clip_fraction)
-                new_clip = float(math.exp(args.log_dp_clip))
-                new_clip = max(min(new_clip, old_clip * 1.1), old_clip * 0.9)
-                args.dp_clip = max(1.0, min(new_clip, args.dp_clip_max))
-                args.log_dp_clip = math.log(args.dp_clip)
+                if not hasattr(args, 'clipper'):
+                    args.clipper = dp_utils.AdaptiveClipper(args.dp_clip, max_clip=args.dp_clip_max)
+                args.dp_clip = args.clipper.update(args.last_clip_fraction, getattr(args, 'q0_9', args.dp_clip))
                 num_clients = len(deltas) or 1
-                if args.dp_noise_clip_ratio is not None:
-                    max_std = args.dp_noise_clip_ratio * args.dp_clip
-                    noise_std = min(old_noise * args.dp_noise_scale / num_clients, max_std)
-                    args.dp_noise = noise_std * num_clients / args.dp_noise_scale
-                else:
-                    args.dp_noise = old_noise
-                    noise_std = args.dp_noise * args.dp_noise_scale / num_clients
-                z = noise_std / args.dp_clip
-                print(f'clip EMA: {args.clip_frac_ema:.4f}, DP clip: {args.dp_clip:.4f}, noise std: {noise_std:.4f}, z: {z:.4f}')
-                logger.info('clip EMA %.4f, DP clip %.4f, noise std %.4f, z %.4f',
-                            args.clip_frac_ema, args.dp_clip, noise_std, z)
+                noise_std = args.dp_noise * args.dp_noise_scale / num_clients
+                print(
+                    f'clip: {args.dp_clip:.4f}, clipped_fraction: {args.last_clip_fraction:.4f}, '
+                    f'q0.9: {args.q0_9:.4f}, noise std: {noise_std:.4f}, epsilon: {epsilon:.4f}'
+                )
+                logger.info(
+                    'clip %.4f, clipped_fraction %.4f, q0.9 %.4f, noise std %.4f, epsilon %.4f',
+                    args.dp_clip,
+                    args.last_clip_fraction,
+                    args.q0_9,
+                    noise_std,
+                    epsilon,
+                )
             if args.server_momentum:
                 delta_w = copy.deepcopy(global_w)
                 for key in delta_w:

--- a/main_text.py
+++ b/main_text.py
@@ -349,7 +349,6 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     N, K, Q = get_n_k_q(args, mode='train')
     total_batch = N * K + N * Q
     sample_rate = total_batch / client_sample_size
-
     if args.dp_mode == 'local' and args.dp_warmup_batches > 0 and dp_params and not getattr(args, 'dp_clip_calibrated', False):
         warm_loader = DataLoader(
             TensorDataset(torch.tensor(X_train_client), torch.tensor(y_train_client)),
@@ -360,12 +359,34 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         if norms:
             new_clip = float(np.percentile(norms, 90))
             args.dp_clip = min(new_clip, args.dp_clip_max)
-            args.log_dp_clip = math.log(max(1.0, args.dp_clip))
             args.dp_clip_calibrated = True
             print(f'warm-up DP clip: {args.dp_clip:.4f}')
         base_model.load_state_dict(model_template.state_dict())
         dp_optimizer.zero_grad()
         head_optimizer.zero_grad()
+
+    if args.dp_mode == 'server' and args.dp_warmup_batches > 0 and not getattr(args, 'dp_clip_calibrated', False):
+        p90s, weights = [], []
+        for net_id in range(args.n_parties):
+            dataidxs = net_dataidx_map[net_id]
+            X_train_client = X_train[dataidxs]
+            y_train_client = y_train[dataidxs]
+            warm_loader = DataLoader(
+                TensorDataset(torch.tensor(X_train_client), torch.tensor(y_train_client)),
+                batch_size=total_batch,
+                shuffle=True,
+            )
+            tmp_model = copy.deepcopy(global_model)
+            warm_opt = optim.SGD(tmp_model.parameters(), lr=args.lr)
+            norms = collect_grad_norms(tmp_model, warm_loader, warm_opt, args.dp_warmup_batches, args.device)
+            if norms:
+                p90s.append(float(np.percentile(norms, 90)))
+                weights.append(len(y_train_client))
+        if p90s:
+            args.dp_clip = dp_utils.initial_clip(p90s, weights, max_clip=args.dp_clip_max)
+            args.dp_clip_calibrated = True
+            print(f'warm-up DP clip: {args.dp_clip:.4f}')
+        args.clipper = dp_utils.AdaptiveClipper(args.dp_clip, max_clip=args.dp_clip_max)
 
     privacy_engine = None
     if args.dp_mode == 'local' and dp_params:
@@ -931,6 +952,7 @@ def aggregate_deltas(
     """
     clipped = []
     clipped_count = 0
+    norms = []
     for delta in deltas.values():
         flat = torch.cat([
             v.view(-1)
@@ -947,13 +969,19 @@ def aggregate_deltas(
             )
         ])
         norm = torch.norm(flat)
+        norms.append(norm.item())
         scale = min(1.0, args.dp_clip / (norm + 1e-12))
         if scale < 1.0:
             clipped_count += 1
         clipped.append({k: v * scale for k, v in delta.items() if 'few_classify' not in k and 'transform_layer' not in k})
     num_clients = len(clipped) or 1
     args.last_clip_fraction = clipped_count / num_clients
+    if norms:
+        args.q0_9 = float(np.percentile(norms, 90))
+    else:
+        args.q0_9 = args.dp_clip
     logging.info('Clipped fraction: %.4f', args.last_clip_fraction)
+    logging.info('q0.9 norm: %.4f', args.q0_9)
     base_noise_std = args.dp_noise * args.dp_noise_scale / num_clients
     logging.info('Effective noise std: %.6f (clients=%d)', base_noise_std, num_clients)
     for key in global_w:
@@ -1209,26 +1237,23 @@ if __name__ == '__main__':
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
             if args.dp_mode == 'server':
-                old_clip, old_noise = args.dp_clip, args.dp_noise
-                decay = 0.9
-                if not hasattr(args, 'last_clip_fraction'):
-                    args.last_clip_fraction = args.dp_target_clip_fraction
-                if not hasattr(args, 'clip_frac_ema'):
-                    args.clip_frac_ema = args.last_clip_fraction
-                else:
-                    args.clip_frac_ema = decay * args.clip_frac_ema + (1 - decay) * args.last_clip_fraction
-                eta = 0.1
-                args.log_dp_clip += eta * (args.clip_frac_ema - args.dp_target_clip_fraction)
-                new_clip = float(math.exp(args.log_dp_clip))
-                new_clip = max(min(new_clip, old_clip * 1.1), old_clip * 0.9)
-                args.dp_clip = max(1.0, min(new_clip, args.dp_clip_max))
-                args.log_dp_clip = math.log(args.dp_clip)
-                args.dp_noise = dp_utils.scale_noise_to_clip(old_noise, old_clip, args.dp_clip)
+                if not hasattr(args, 'clipper'):
+                    args.clipper = dp_utils.AdaptiveClipper(args.dp_clip, max_clip=args.dp_clip_max)
+                args.dp_clip = args.clipper.update(args.last_clip_fraction, getattr(args, 'q0_9', args.dp_clip))
                 num_clients = len(deltas) or 1
                 noise_std = args.dp_noise * args.dp_noise_scale / num_clients
-                z = noise_std / args.dp_clip
-                print(f'clip EMA: {args.clip_frac_ema:.4f}, DP clip: {args.dp_clip:.4f}, z: {z:.4f}')
-                logger.info('clip EMA %.4f, DP clip %.4f, z %.4f', args.clip_frac_ema, args.dp_clip, z)
+                print(
+                    f'clip: {args.dp_clip:.4f}, clipped_fraction: {args.last_clip_fraction:.4f}, '
+                    f'q0.9: {args.q0_9:.4f}, noise_std: {noise_std:.4f}, epsilon: {epsilon:.4f}'
+                )
+                logger.info(
+                    'clip %.4f, clipped_fraction %.4f, q0.9 %.4f, noise std %.4f, epsilon %.4f',
+                    args.dp_clip,
+                    args.last_clip_fraction,
+                    args.q0_9,
+                    noise_std,
+                    epsilon,
+                )
             if args.server_momentum:
                 delta_w = copy.deepcopy(global_w)
                 for key in delta_w:

--- a/tests/test_adaptive_clipper.py
+++ b/tests/test_adaptive_clipper.py
@@ -1,0 +1,52 @@
+import numpy as np
+import dp_utils
+
+
+def run_sim(dist_fn, rounds=120, clip=1.0, rng=None):
+    rng = rng or np.random.default_rng(0)
+    clipper = dp_utils.AdaptiveClipper(clip)
+    for t in range(rounds):
+        norms = dist_fn(rng, t)
+        q90 = float(np.percentile(norms, 90))
+        clipped_fraction = float(np.mean(norms > clipper.clip))
+        clipper.update(clipped_fraction, q90)
+    return clipper, clipped_fraction
+
+
+def test_stationary_lognormal():
+    def dist(rng, _):
+        return rng.lognormal(mean=0.0, sigma=1.0, size=1000)
+    clipper, clipped_fraction = run_sim(dist)
+    assert abs(clipped_fraction - clipper.target) <= 0.03
+
+
+def test_drift_recovery():
+    def dist(rng, t):
+        sigma = 1.0 if t < 60 else 1.5
+        return rng.lognormal(mean=0.0, sigma=sigma, size=1000)
+    clipper = dp_utils.AdaptiveClipper(1.0)
+    rng = np.random.default_rng(1)
+    recovered = False
+    overshoot = 0.0
+    for t in range(120):
+        norms = dist(rng, t)
+        q90 = float(np.percentile(norms, 90))
+        clipped_fraction = float(np.mean(norms > clipper.clip))
+        clipper.update(clipped_fraction, q90)
+        if t >= 60 and not recovered:
+            if abs(clipped_fraction - clipper.target) <= 0.05:
+                recovered = True
+        if t >= 60:
+            overshoot = max(overshoot, abs(clipped_fraction - clipper.target))
+    assert recovered
+    assert overshoot <= 0.20
+
+
+def test_heavy_tail_robustness():
+    def dist(rng, _):
+        base = rng.lognormal(mean=0.0, sigma=1.0, size=1000)
+        n_out = max(1, int(0.01 * base.size))
+        base[:n_out] = rng.pareto(2.0, size=n_out) * 20
+        return base
+    clipper, clipped_fraction = run_sim(dist, rng=np.random.default_rng(2))
+    assert abs(clipped_fraction - clipper.target) <= 0.05


### PR DESCRIPTION
## Summary
- calibrate initial server-side DP clip by aggregating per-client 90th percentile norms via weighted median
- add log-space controller blending clipped-fraction feedback with running percentile and bounds
- exercise adaptive clipper with unit tests covering stationary, drift, and heavy-tail scenarios

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest tests/test_adaptive_clipper.py`


------
https://chatgpt.com/codex/tasks/task_e_68b00f823114832aa9e5c4ac02e138ad