### PR TITLE
Expose configurable DP clipping bounds and saturation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The repository now includes optional support for a **personalised transformation
   * `server`: clip and noise client updates on the server.
   * `off`: disable differential privacy.
   * `--dp_clip`: clipping norm (default `1.0`)
+  * `--dp_clip_min`: lower bound for adaptive clipping (default `1.2`)
+  * `--dp_clip_max`: upper bound for adaptive clipping (default `6.0`; when warm-up is used it becomes `round_up(max(6.0, 1.5 * warmup_p90))`)
+  * `--dp_clip_step_cap`: limit per-round clip changes to this fraction (default `0.10`)
   * `--dp_noise`: noise multiplier
   * `--dp_noise_clip_ratio`: cap noise standard deviation to this fraction of the clip bound
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)

--- a/dp_utils.py
+++ b/dp_utils.py
@@ -229,11 +229,27 @@ def stabilize_adaptive_clip(args, epsilon, num_clients, logger=logging):
         log_perc = 0.9 * log_c + 0.1 * math.log(q90)
         log_blend = 0.5 * log_ctrl + 0.5 * log_perc
         cand = math.exp(log_blend)
-        cand = max(0.9 * args.dp_clip, min(1.1 * args.dp_clip, cand))
-        new_clip = min(max(cand, 1.2), 5.0)
+        step = getattr(args, 'dp_clip_step_cap', 0.10)
+        low_step = args.dp_clip * (1.0 - step)
+        high_step = args.dp_clip * (1.0 + step)
+        cand = max(low_step, min(high_step, cand))
+        dp_min = getattr(args, 'dp_clip_min', 1.2)
+        dp_max = getattr(args, 'dp_clip_max', 5.0)
+        new_clip = max(dp_min, min(dp_max, cand))
     args.dp_clip = new_clip
     args.log_dp_clip = math.log(args.dp_clip)
     noise_std = args.dp_noise * args.dp_noise_scale / num_clients
+    if getattr(args, 'last_clip_fraction', 0.0) > 0.95:
+        args.saturation_ctr = getattr(args, 'saturation_ctr', 0) + 1
+    else:
+        args.saturation_ctr = 0
+    if getattr(args, 'saturation_ctr', 0) >= 3 and args.dp_clip >= 0.98 * getattr(args, 'dp_clip_max', args.dp_clip):
+        msg = (
+            'Clipped ~100%, controller saturated at dp_clip_max. '
+            'Raise --dp_clip_max (try ×1.5) or reduce local drift (epochs/μ).'
+        )
+        print(f'WARNING: {msg}')
+        logger.warning(msg)
     print(f"clip EMA: {args.clip_frac_ema:.4f}, q90: {getattr(args, 'q90', 0.0):.4f}, DP clip: {args.dp_clip:.4f}, noise std: {noise_std:.4f}, eps: {epsilon or 0.0:.4f}")
     logger.info(
         'DP clip %.4f, clip EMA %.4f, q90 %.4f, noise std %.4f, eps %.4f',

--- a/main_image.py
+++ b/main_image.py
@@ -222,12 +222,15 @@ def get_args():
     parser.add_argument('--use_transform_layer', type=int, default=0,
                         help='enable personalized transformation layer')
     parser.add_argument('--dp_clip', type=float, default=1.0, help='DP-SGD clipping norm')
+    parser.add_argument('--dp_clip_min', type=float, default=1.2, help='minimum DP-SGD clipping norm')
+    parser.add_argument('--dp_clip_max', type=float, default=6.0, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--dp_clip_step_cap', type=float, default=0.10,
+                        help='limit relative DP clip change per round')
     parser.add_argument('--dp_noise', type=float, default=0.0, help='DP-SGD noise multiplier')
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
     parser.add_argument('--dp_noise_clip_ratio', type=float, default=None,
                         help='cap noise std to this fraction of the clip bound')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
-    parser.add_argument('--dp_clip_max', type=float, default=20.0, help='maximum DP-SGD clipping norm')
     parser.add_argument('--dp_warmup_batches', type=int, default=0, help='warm-up batches for DP clip calibration')
     parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
                         help='target fraction of clients to be clipped')
@@ -237,7 +240,8 @@ def get_args():
     parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
     parser.add_argument('--use_amp', action='store_true', help='enable mixed precision training')
     args = parser.parse_args()
-    args.dp_clip = min(args.dp_clip, args.dp_clip_max)
+    args.dp_clip_max = max(args.dp_clip_max, args.dp_clip_min)
+    args.dp_clip = max(args.dp_clip_min, min(args.dp_clip, args.dp_clip_max))
     args.log_dp_clip = math.log(max(1.0, args.dp_clip))
     return args
 
@@ -367,7 +371,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         norms = collect_grad_norms(base_model, warm_loader, dp_optimizer, args.dp_warmup_batches, args.device)
         if norms:
             new_clip = float(np.percentile(norms, 90))
-            args.dp_clip = min(new_clip, args.dp_clip_max)
+            args.dp_clip_max = max(args.dp_clip_max, math.ceil(max(6.0, 1.5 * new_clip)))
+            args.dp_clip = max(args.dp_clip_min, min(new_clip, args.dp_clip_max))
             args.log_dp_clip = math.log(max(1.0, args.dp_clip))
             args.dp_clip_calibrated = True
             print(f'warm-up DP clip: {args.dp_clip:.4f}')
@@ -825,7 +830,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
         if args.dp_mode == 'local' and args.grad_norms_ma:
             new_clip = float(np.percentile(list(args.grad_norms_ma.values()), 90))
-            args.dp_clip = min(new_clip, args.dp_clip_max)
+            args.dp_clip = max(args.dp_clip_min, min(new_clip, args.dp_clip_max))
+            args.log_dp_clip = math.log(max(1.0, args.dp_clip))
             print(f'90th percentile: {new_clip:.4f}, DP clip: {args.dp_clip:.4f}')
             logger.info('90th percentile %.4f, DP clip %.4f', new_clip, args.dp_clip)
         if np.random.rand() < 0.3:

--- a/main_text.py
+++ b/main_text.py
@@ -215,10 +215,13 @@ def get_args():
                         help='enable personalized transformation layer')
     parser.add_argument('--use_dp', type=int, default=0, help='enable DP-SGD')
     parser.add_argument('--dp_clip', type=float, default=1.0, help='DP-SGD clipping norm')
+    parser.add_argument('--dp_clip_min', type=float, default=1.2, help='minimum DP-SGD clipping norm')
+    parser.add_argument('--dp_clip_max', type=float, default=6.0, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--dp_clip_step_cap', type=float, default=0.10,
+                        help='limit relative DP clip change per round')
     parser.add_argument('--dp_noise', type=float, default=0.0, help='DP-SGD noise multiplier')
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
-    parser.add_argument('--dp_clip_max', type=float, default=2.0, help='maximum DP-SGD clipping norm')
     parser.add_argument('--dp_warmup_batches', type=int, default=0, help='warm-up batches for DP clip calibration')
     parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
                         help='target fraction of clients to be clipped')
@@ -229,7 +232,8 @@ def get_args():
     parser.add_argument('--use_amp', action='store_true', help='enable mixed precision training')
     args = parser.parse_args()
     args.use_dp = int(args.dp_mode != 'off')
-    args.dp_clip = min(args.dp_clip, args.dp_clip_max)
+    args.dp_clip_max = max(args.dp_clip_max, args.dp_clip_min)
+    args.dp_clip = max(args.dp_clip_min, min(args.dp_clip, args.dp_clip_max))
     args.log_dp_clip = math.log(max(1.0, args.dp_clip))
     return args
 
@@ -359,7 +363,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         norms = collect_grad_norms(base_model, warm_loader, dp_optimizer, args.dp_warmup_batches, args.device)
         if norms:
             new_clip = float(np.percentile(norms, 90))
-            args.dp_clip = min(new_clip, args.dp_clip_max)
+            args.dp_clip_max = max(args.dp_clip_max, math.ceil(max(6.0, 1.5 * new_clip)))
+            args.dp_clip = max(args.dp_clip_min, min(new_clip, args.dp_clip_max))
             args.log_dp_clip = math.log(max(1.0, args.dp_clip))
             args.dp_clip_calibrated = True
             print(f'warm-up DP clip: {args.dp_clip:.4f}')
@@ -792,7 +797,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
         if args.dp_mode == 'local' and args.grad_norms_ma:
             new_clip = float(np.percentile(list(args.grad_norms_ma.values()), 90))
-            args.dp_clip = new_clip
+            args.dp_clip = max(args.dp_clip_min, min(new_clip, args.dp_clip_max))
+            args.log_dp_clip = math.log(max(1.0, args.dp_clip))
             print(f'90th percentile: {new_clip:.4f}, DP clip: {args.dp_clip:.4f}')
             logger.info('90th percentile %.4f, DP clip %.4f', new_clip, args.dp_clip)
         if np.random.rand() < 0.3:


### PR DESCRIPTION
## Summary
- expose `--dp_clip_min`, `--dp_clip_max`, and `--dp_clip_step_cap` to control DP clipping bounds
- remove hard-coded clip limits and add saturation warning in adaptive controller
- document new DP clipping options

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b0234a1a14832a8addcde91653b986