### PR TITLE
Use per-round norm stats for adaptive clipping

### DIFF
--- a/dp_utils.py
+++ b/dp_utils.py
@@ -190,7 +190,15 @@ def weighted_median(values, weights):
     return float(values[cdf >= cutoff][0])
 
 
-def stabilize_adaptive_clip(args, epsilon, num_clients, logger=logging):
+def stabilize_adaptive_clip(
+    args,
+    epsilon,
+    num_clients,
+    round_p90,
+    round_p50=None,
+    frac_now=None,
+    logger=logging,
+):
     '''Update the DP-SGD clipping bound using a stabilized controller.
 
     Parameters
@@ -202,6 +210,12 @@ def stabilize_adaptive_clip(args, epsilon, num_clients, logger=logging):
         Current cumulative privacy loss.
     num_clients : int
         Number of participating clients in the current round.
+    round_p90 : float
+        90th percentile of gradient norms from the current round.
+    round_p50 : float, optional
+        Median of gradient norms from the current round.
+    frac_now : float, optional
+        Fraction of client norms exceeding the clipping bound.
     logger : logging.Logger, optional
         Logger used for reporting statistics.
 
@@ -210,6 +224,10 @@ def stabilize_adaptive_clip(args, epsilon, num_clients, logger=logging):
     float
         Updated clipping bound.
     '''
+    if round_p50 is not None:
+        args.round_p50 = round_p50
+    if frac_now is not None:
+        args.frac_now = frac_now
     p_t = max(0.02, min(0.98, getattr(args, 'last_clip_fraction', 0.0)))
     if not hasattr(args, 'clip_frac_ema'):
         args.clip_frac_ema = p_t
@@ -225,8 +243,8 @@ def stabilize_adaptive_clip(args, epsilon, num_clients, logger=logging):
     else:
         log_c = math.log(args.dp_clip)
         log_ctrl = log_c + 0.05 * (args.clip_frac_ema - target)
-        q90 = max(getattr(args, 'q90', args.dp_clip), 1e-12)
-        log_perc = 0.9 * log_c + 0.1 * math.log(q90)
+        perc = max(round_p90, 1e-12)
+        log_perc = 0.9 * log_c + 0.1 * math.log(perc)
         log_blend = 0.5 * log_ctrl + 0.5 * log_perc
         cand = math.exp(log_blend)
         step = getattr(args, 'dp_clip_step_cap', 0.10)
@@ -250,12 +268,15 @@ def stabilize_adaptive_clip(args, epsilon, num_clients, logger=logging):
         )
         print(f'WARNING: {msg}')
         logger.warning(msg)
-    print(f"clip EMA: {args.clip_frac_ema:.4f}, q90: {getattr(args, 'q90', 0.0):.4f}, DP clip: {args.dp_clip:.4f}, noise std: {noise_std:.4f}, eps: {epsilon or 0.0:.4f}")
+    print(
+        f"clip EMA: {args.clip_frac_ema:.4f}, hist q90: {getattr(args, 'q90', 0.0):.4f}, round p90: {round_p90:.4f}, DP clip: {args.dp_clip:.4f}, noise std: {noise_std:.4f}, eps: {epsilon or 0.0:.4f}"
+    )
     logger.info(
-        'DP clip %.4f, clip EMA %.4f, q90 %.4f, noise std %.4f, eps %.4f',
+        'DP clip %.4f, clip EMA %.4f, hist q90 %.4f, round p90 %.4f, noise std %.4f, eps %.4f',
         args.dp_clip,
         args.clip_frac_ema,
         getattr(args, 'q90', 0.0),
+        round_p90,
         noise_std,
         epsilon or 0.0,
     )

--- a/main_image.py
+++ b/main_image.py
@@ -956,7 +956,9 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
     Noise is scaled by the number of participating clients to maintain the
     expected privacy budget regardless of the number of contributions. The
     fraction of client updates that were clipped is stored in
-    ``args.last_clip_fraction`` for adaptive clipping strategies.
+    ``args.last_clip_fraction`` for adaptive clipping strategies. Per-round
+    gradient norm percentiles are recorded in ``args.round_p50`` and
+    ``args.round_p90`` for use by adaptive clipping controllers.
 
     Args:
         global_w (dict): Global model weights to be updated.
@@ -990,7 +992,14 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
         scales.append(scale)
         clipped.append({k: v * scale for k, v in delta.items() if 'few_classify' not in k and 'transform_layer' not in k})
     num_clients = len(clipped) or 1
-    args.last_clip_fraction = float(np.mean([s < 1.0 for s in scales])) if scales else 0.0
+    round_norms = [n for _, n in norms]
+    round_p50 = float(np.percentile(round_norms, 50)) if round_norms else 0.0
+    round_p90 = float(np.percentile(round_norms, 90)) if round_norms else 0.0
+    frac_now = float(np.mean([n > args.dp_clip for n in round_norms])) if round_norms else 0.0
+    args.round_p50 = round_p50
+    args.round_p90 = round_p90
+    args.frac_now = frac_now
+    args.last_clip_fraction = frac_now
     logging.info('Clipped fraction: %.4f', args.last_clip_fraction)
     if not hasattr(args, 'grad_norm_histories'):
         args.grad_norm_histories = {}
@@ -1264,7 +1273,14 @@ if __name__ == '__main__':
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
             if args.dp_mode == 'server':
-                dp_utils.stabilize_adaptive_clip(args, epsilon or 0.0, len(deltas) or 1)
+                dp_utils.stabilize_adaptive_clip(
+                    args,
+                    epsilon or 0.0,
+                    len(deltas) or 1,
+                    args.round_p90,
+                    round_p50=args.round_p50,
+                    frac_now=args.frac_now,
+                )
             if args.server_momentum:
                 delta_w = copy.deepcopy(global_w)
                 for key in delta_w:

--- a/main_text.py
+++ b/main_text.py
@@ -925,8 +925,10 @@ def aggregate_deltas(
     Noise is scaled by the number of participating clients. When
     ``noise_multipliers`` is provided, parameter-specific multipliers are applied
     on top of the base noise multiplier ``args.dp_noise``. The fraction of
-    client updates that were clipped is stored in
-    ``args.last_clip_fraction`` for adaptive clipping strategies.
+    client updates that were clipped is stored in ``args.last_clip_fraction`` for
+    adaptive clipping strategies. Per-round gradient norm percentiles are
+    recorded in ``args.round_p50`` and ``args.round_p90`` for use by adaptive
+    controllers.
 
     Args:
         global_w (dict): Global model weights to be updated.
@@ -936,7 +938,6 @@ def aggregate_deltas(
         reset_bn (bool, optional): Reset BatchNorm statistics after aggregation.
     """
     clipped = []
-    clipped_count = 0
     norms = []
     for cid, delta in deltas.items():
         flat = torch.cat([
@@ -956,11 +957,16 @@ def aggregate_deltas(
         norm = torch.norm(flat).item()
         norms.append((cid, norm))
         scale = min(1.0, args.dp_clip / (norm + 1e-12))
-        if scale < 1.0:
-            clipped_count += 1
         clipped.append({k: v * scale for k, v in delta.items() if 'few_classify' not in k and 'transform_layer' not in k})
     num_clients = len(clipped) or 1
-    args.last_clip_fraction = clipped_count / num_clients
+    round_norms = [n for _, n in norms]
+    round_p50 = float(np.percentile(round_norms, 50)) if round_norms else 0.0
+    round_p90 = float(np.percentile(round_norms, 90)) if round_norms else 0.0
+    frac_now = float(np.mean([n > args.dp_clip for n in round_norms])) if round_norms else 0.0
+    args.round_p50 = round_p50
+    args.round_p90 = round_p90
+    args.frac_now = frac_now
+    args.last_clip_fraction = frac_now
     logging.info('Clipped fraction: %.4f', args.last_clip_fraction)
     if not hasattr(args, 'grad_norm_histories'):
         args.grad_norm_histories = {}
@@ -1183,7 +1189,14 @@ if __name__ == '__main__':
                     logger.info(
                         '>> Global 5 Model Test accuracy: {:.4f} Best Acc: {:.4f} '.format(global_acc, best_acc_5))
             if args.dp_mode == 'server':
-                dp_utils.stabilize_adaptive_clip(args, epsilon or 0.0, len(deltas) or 1)
+                dp_utils.stabilize_adaptive_clip(
+                    args,
+                    epsilon or 0.0,
+                    len(deltas) or 1,
+                    args.round_p90,
+                    round_p50=args.round_p50,
+                    frac_now=args.frac_now,
+                )
             if args.server_momentum:
                 delta_w = copy.deepcopy(global_w)
                 for key in delta_w:


### PR DESCRIPTION
## Summary
- compute round-wise gradient norm percentiles and clipping fraction in server aggregation
- pass per-round p90 to adaptive DP controller and anchor clipping updates on it

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b03b3f0fbc832a82401e0964466bf1