### PR TITLE
Refine BatchNorm conversion for DP modes

### DIFF
--- a/bn_utils.py
+++ b/bn_utils.py
@@ -1,19 +1,55 @@
+import logging
 import torch.nn as nn
 
 
-def convert_batchnorm_modules(module):
-    """Replace all ``nn.BatchNorm2d`` layers with ``nn.GroupNorm``.
+def _select_num_groups(channels):
+    """Return a suitable ``GroupNorm`` group count for ``channels``.
+
+    The largest power-of-two divisor not exceeding 32 is preferred. If no such
+    divisor exists, the largest divisor \u2264 32 is used. A warning is logged
+    when falling back to 1.
+    """
+    for ng in (32, 16, 8, 4, 2):
+        if ng <= channels and channels % ng == 0:
+            return ng
+    for ng in range(min(32, channels), 1, -1):
+        if channels % ng == 0:
+            return ng
+    logging.warning('Could not find a suitable GroupNorm divisor for %d channels; using 1 group', channels)
+    return 1
+
+
+def convert_batchnorm_modules(module, dp_mode='local'):
+    """Replace ``BatchNorm`` layers with DP-friendly alternatives.
 
     Parameters
     ----------
     module : nn.Module
         Model to be converted in-place.
+    dp_mode : str, optional
+        Differential privacy mode. When ``'local'`` BatchNorm layers are
+        replaced with ``GroupNorm``. For ``'server'`` or ``'off'`` BatchNorm
+        layers are kept in evaluation mode.
     """
     for name, child in module.named_children():
-        if isinstance(child, nn.BatchNorm2d):
-            gn = nn.GroupNorm(1, child.num_features, affine=child.affine, eps=child.eps)
+        if isinstance(child, nn.GroupNorm):
+            convert_batchnorm_modules(child, dp_mode)
+            continue
+
+        if isinstance(child, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.SyncBatchNorm)):
+            if dp_mode != 'local':
+                child.eval()
+                convert_batchnorm_modules(child, dp_mode)
+                continue
+
+            num_groups = _select_num_groups(child.num_features)
+            gn = nn.GroupNorm(num_groups, child.num_features, affine=child.affine, eps=child.eps)
+            if child.affine:
+                gn.weight.data.copy_(child.weight.data)
+                gn.bias.data.copy_(child.bias.data)
             setattr(module, name, gn)
+            convert_batchnorm_modules(gn, dp_mode)
         else:
-            convert_batchnorm_modules(child)
+            convert_batchnorm_modules(child, dp_mode)
     return module
 

--- a/model.py
+++ b/model.py
@@ -277,12 +277,13 @@ def resnet12(keep_prob=1.0, avg_pool=False, drop_rate=0.0, dp_mode='off', **kwar
     """Constructs a ResNet-12 model.
 
     BatchNorm layers are converted and validated for differential privacy when
-    ``dp_mode`` is not ``'off'``.
+    ``dp_mode`` is ``'local'``.
     """
     model = ResNet(BasicBlock, keep_prob=keep_prob, avg_pool=avg_pool, drop_rate=drop_rate, **kwargs)
     if dp_mode != 'off':
-        model = convert_batchnorm_modules(model)
-        ModuleValidator.validate(model, strict=True)
+        model = convert_batchnorm_modules(model, dp_mode)
+        if dp_mode == 'local':
+            ModuleValidator.validate(model, strict=True)
     return model
 
 

--- a/resnetcifar.py
+++ b/resnetcifar.py
@@ -212,13 +212,14 @@ def ResNet18_cifar10(dp_mode='off', **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
-        dp_mode (str): Differential privacy mode; when not ``'off'`` BatchNorm
+        dp_mode (str): Differential privacy mode; when ``'local'`` BatchNorm
             layers are converted and validated for DP.
     """
     model = ResNetCifar10(BasicBlock, [2, 2, 2, 2], **kwargs)
     if dp_mode != 'off':
-        model = convert_batchnorm_modules(model)
-        ModuleValidator.validate(model, strict=True)
+        model = convert_batchnorm_modules(model, dp_mode)
+        if dp_mode == 'local':
+            ModuleValidator.validate(model, strict=True)
     return model
 
 
@@ -230,11 +231,12 @@ def ResNet50_cifar10(dp_mode='off', **kwargs):
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
         progress (bool): If True, displays a progress bar of the download to stderr
-        dp_mode (str): Differential privacy mode; when not ``'off'`` BatchNorm
+        dp_mode (str): Differential privacy mode; when ``'local'`` BatchNorm
             layers are converted and validated for DP.
     """
     model = ResNetCifar10(Bottleneck, [3, 4, 6, 3], **kwargs)
     if dp_mode != 'off':
-        model = convert_batchnorm_modules(model)
-        ModuleValidator.validate(model, strict=True)
+        model = convert_batchnorm_modules(model, dp_mode)
+        if dp_mode == 'local':
+            ModuleValidator.validate(model, strict=True)
     return model

--- a/tests/test_bn_utils.py
+++ b/tests/test_bn_utils.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import torch.nn as nn
+from opacus.validators import ModuleValidator
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from bn_utils import convert_batchnorm_modules
+
+
+class Dummy(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 48, 3, padding=1, bias=False)
+        self.bn = nn.BatchNorm2d(48)
+
+    def forward(self, x):
+        return self.bn(self.conv(x))
+
+
+m = Dummy()
+convert_batchnorm_modules(m, dp_mode='local')
+convert_batchnorm_modules(m, dp_mode='local')
+ModuleValidator.validate(m, strict=True)
+print('num_groups', m.bn.num_groups)


### PR DESCRIPTION
## Summary
- compute GroupNorm groups from channel divisors and handle DP modes
- update ResNet builders to pass dp_mode and validate only for local DP
- add test exercising BatchNorm conversion

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python tests/test_bn_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b57d3e28c4832a83f941bd14475fc3