### PR TITLE
Exclude all_classify layers from DP and aggregation

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -287,8 +287,13 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     client_sample_size = len(y_train_client)
 
     dp_named_params = [
-        (n, p) for n, p in base_model.named_parameters()
-        if 'transform_layer' not in n and 'few_classify' not in n and 'transformer' not in n and p.requires_grad
+        (n, p)
+        for n, p in base_model.named_parameters()
+        if 'transform_layer' not in n
+        and 'few_classify' not in n
+        and 'transformer' not in n
+        and 'all_classify' not in n
+        and p.requires_grad
     ]
     dp_params = [p for _, p in dp_named_params]
     head_params = list(base_model.few_classify.parameters())
@@ -362,8 +367,13 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             head_optimizer, T_max=n_epoch, eta_min=lr * args.lr_decay
         )
     dp_named_params = [
-        (n, p) for n, p in gmodel.named_parameters()
-        if 'transform_layer' not in n and 'few_classify' not in n and 'transformer' not in n and p.requires_grad
+        (n, p)
+        for n, p in gmodel.named_parameters()
+        if 'transform_layer' not in n
+        and 'few_classify' not in n
+        and 'transformer' not in n
+        and 'all_classify' not in n
+        and p.requires_grad
     ]
     if not hasattr(args, 'grad_norms_ma'):
         args.grad_norms_ma = {}
@@ -905,6 +915,7 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
                     'running_var',
                     'num_batches_tracked',
                     'few_classify',
+                    'all_classify',
                     'transform_layer',
                 )
             )
@@ -913,7 +924,13 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
         scale = min(1.0, args.dp_clip / (norm + 1e-12))
         logging.info('Client %s norm %.4f scale %.4f', cid, norm, scale)
         scales.append(scale)
-        clipped.append({k: v * scale for k, v in delta.items() if 'few_classify' not in k and 'transform_layer' not in k})
+        clipped.append(
+            {
+                k: v * scale
+                for k, v in delta.items()
+                if 'few_classify' not in k and 'all_classify' not in k and 'transform_layer' not in k
+            }
+        )
     num_clients = len(clipped) or 1
     args.last_clip_fraction = float(np.mean([s < 1.0 for s in scales])) if scales else 0.0
     logging.info('Clipped fraction: %.4f', getattr(args, 'last_clip_fraction', args.dp_target_clip_fraction))
@@ -922,7 +939,7 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
     base_noise_std = args.dp_noise * args.dp_noise_scale / num_clients
     logging.info('Effective noise std: %.6f (clients=%d)', base_noise_std, num_clients)
     for key in global_w:
-        if 'few_classify' in key:
+        if 'few_classify' in key or 'all_classify' in key:
             continue
         if any(s in key for s in ('running_mean', 'running_var', 'num_batches_tracked')):
             if 'num_batches_tracked' in key:

--- a/main_text.py
+++ b/main_text.py
@@ -281,8 +281,13 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     client_sample_size = len(y_train_client)
 
     dp_named_params = [
-        (n, p) for n, p in base_model.named_parameters()
-        if 'transform_layer' not in n and 'few_classify' not in n and 'transformer' not in n and p.requires_grad
+        (n, p)
+        for n, p in base_model.named_parameters()
+        if 'transform_layer' not in n
+        and 'few_classify' not in n
+        and 'transformer' not in n
+        and 'all_classify' not in n
+        and p.requires_grad
     ]
     dp_params = [p for _, p in dp_named_params]
     head_params = list(base_model.few_classify.parameters())
@@ -347,8 +352,13 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         dp_optimizer.sample_rate = sample_rate
         dp_optimizer.expected_batch_size = total_batch
     dp_named_params = [
-        (n, p) for n, p in gmodel.named_parameters()
-        if 'transform_layer' not in n and 'few_classify' not in n and 'transformer' not in n and p.requires_grad
+        (n, p)
+        for n, p in gmodel.named_parameters()
+        if 'transform_layer' not in n
+        and 'few_classify' not in n
+        and 'transformer' not in n
+        and 'all_classify' not in n
+        and p.requires_grad
     ]
     if not hasattr(args, 'grad_norms_ma'):
         args.grad_norms_ma = {}
@@ -879,6 +889,7 @@ def aggregate_deltas(
                     'running_var',
                     'num_batches_tracked',
                     'few_classify',
+                    'all_classify',
                     'transform_layer',
                 )
             )
@@ -887,14 +898,20 @@ def aggregate_deltas(
         scale = min(1.0, args.dp_clip / (norm + 1e-12))
         if scale < 1.0:
             clipped_count += 1
-        clipped.append({k: v * scale for k, v in delta.items() if 'few_classify' not in k and 'transform_layer' not in k})
+        clipped.append(
+            {
+                k: v * scale
+                for k, v in delta.items()
+                if 'few_classify' not in k and 'all_classify' not in k and 'transform_layer' not in k
+            }
+        )
     num_clients = len(clipped) or 1
     args.last_clip_fraction = clipped_count / num_clients
     logging.info('Clipped fraction: %.4f', getattr(args, 'last_clip_fraction', args.dp_target_clip_fraction))
     base_noise_std = args.dp_noise * args.dp_noise_scale / num_clients
     logging.info('Effective noise std: %.6f (clients=%d)', base_noise_std, num_clients)
     for key in global_w:
-        if 'few_classify' in key:
+        if 'few_classify' in key or 'all_classify' in key:
             continue
         if any(s in key for s in ('running_mean', 'running_var', 'num_batches_tracked')):
             global_w[key] += torch.stack([d[key] for d in deltas.values()]).mean(0)


### PR DESCRIPTION
## Summary
- ignore `all_classify` layers when gathering DP-named params in image and text training
- skip `all_classify` weights during update clipping and noise addition

## Testing
- `python -m py_compile main_image.py main_text.py`

------
https://chatgpt.com/codex/tasks/task_e_68b69e3db384832a924dd0e0e24f859b