### PR TITLE
Remove dynamic clipping bounds

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -1178,7 +1178,7 @@ if __name__ == '__main__':
                 eta = 0.1
                 args.log_dp_clip += eta * (args.clip_frac_ema - args.dp_target_clip_fraction)
                 new_clip = float(math.exp(args.log_dp_clip))
-                new_clip = max(min(new_clip, old_clip * 1.1), old_clip * 0.9)
+                # new_clip = max(min(new_clip, old_clip * 1.1), old_clip * 0.9)
                 args.dp_clip = max(1.0, min(new_clip, args.dp_clip_max))
                 args.log_dp_clip = math.log(args.dp_clip)
                 args.dp_noise = dp_utils.scale_noise_to_clip(old_noise, old_clip, args.dp_clip)

--- a/main_text.py
+++ b/main_text.py
@@ -1144,7 +1144,7 @@ if __name__ == '__main__':
                 eta = 0.1
                 args.log_dp_clip += eta * (args.clip_frac_ema - args.dp_target_clip_fraction)
                 new_clip = float(math.exp(args.log_dp_clip))
-                new_clip = max(min(new_clip, old_clip * 1.1), old_clip * 0.9)
+                # new_clip = max(min(new_clip, old_clip * 1.1), old_clip * 0.9)
                 args.dp_clip = max(1.0, min(new_clip, args.dp_clip_max))
                 args.log_dp_clip = math.log(args.dp_clip)
                 args.dp_noise = dp_utils.scale_noise_to_clip(old_noise, old_clip, args.dp_clip)


### PR DESCRIPTION
## Summary
- avoid constraining new DP clip by previous bounds in image training
- same relaxation for text training to respect only `dp_clip_max`

## Testing
- `python -B -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b7cbc99dc4832aa35ce551866cc528