### PR TITLE
Disable autocast for logistic regression

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -700,13 +700,13 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                         X_out_sup = X_out_all[:N * K]
                         X_out_query = X_out_all[N * K:]
 
-                    support_features = torch.nan_to_num(l2_normalize(X_out_sup), nan=0.0, posinf=0.0, neginf=0.0)
-                    query_features = torch.nan_to_num(l2_normalize(X_out_query), nan=0.0, posinf=0.0, neginf=0.0)
+                    support_features = torch.nan_to_num(l2_normalize(X_out_sup), nan=0.0, posinf=0.0, neginf=0.0).float()
+                    query_features = torch.nan_to_num(l2_normalize(X_out_query), nan=0.0, posinf=0.0, neginf=0.0).float()
 
-                    clf = LogisticRegression(support_features.size(1), N).to(support_features.device)
-                    clf.fit(support_features, support_labels, max_iter=1000)
-
-                    out = clf.predict_proba(query_features)
+                    clf = LogisticRegression(support_features.size(1), N).to(support_features.device).float()
+                    with autocast(enabled=False):
+                        clf.fit(support_features, support_labels, max_iter=1000)
+                        out = clf.predict_proba(query_features)
 
                     acc_train = (torch.argmax(out, -1) == query_labels).float().mean().item()
                     max_value, index = torch.max(out, -1)

--- a/main_text.py
+++ b/main_text.py
@@ -675,9 +675,9 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     query_features = torch.nan_to_num(l2_normalize(X_out_query), nan=0.0, posinf=0.0, neginf=0.0).float()
 
                     clf = LogisticRegression(support_features.size(1), N).to(support_features.device).float()
-                    clf.fit(support_features, support_labels, max_iter=1000)
-
-                    out = clf.predict_proba(query_features)
+                    with autocast(enabled=False):
+                        clf.fit(support_features, support_labels, max_iter=1000)
+                        out = clf.predict_proba(query_features)
 
                     acc_train = (torch.argmax(out, -1) == query_labels).float().mean().item()
                     max_value, index = torch.max(out, -1)


### PR DESCRIPTION
## Summary
- ensure logistic regression features and classifier use float32 in image and text pipelines
- run classifier training and inference with autocast disabled to maintain precision

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b7eb35e634832a8f624c90802b31e5