### PR TITLE
Unscale DP grad samples under AMP

### DIFF
--- a/main_text.py
+++ b/main_text.py
@@ -576,6 +576,9 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                 if use_amp:
                     scaler.scale(loss_all).backward()
                     scaler.unscale_(dp_optimizer)
+                    for _, param in dp_named_params:
+                        if hasattr(param, 'grad_sample') and param.grad_sample is not None:
+                            param.grad_sample = (param.grad_sample / scaler.get_scale()).float()
                     scaler.unscale_(head_optimizer)
                     if tl_optimizer is not None:
                         scaler.unscale_(tl_optimizer)


### PR DESCRIPTION
## Summary
- ensure DP per-sample gradients are unscaled and cast to float when using AMP

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b7f0d3e338832a8f28462bc436b5b6