### PR TITLE
Add DP constant noise flag for adaptive clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The repository now includes optional support for a **personalised transformation
   * `off`: disable differential privacy.
   * `--dp_clip`: clipping norm (default `1.0`)
   * `--dp_noise`: noise multiplier
+  * `--dp_constant_noise`: keep the noise multiplier σ fixed when adapting the clipping norm so the base noise standard deviation remains constant across rounds
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)
   * `--print_eps`: output the current ε after each communication round when set to `1`
   * `--dp_target_clip_fraction`: desired fraction of client updates to clip (default `0.1`)

--- a/main_image.py
+++ b/main_image.py
@@ -202,6 +202,8 @@ def get_args():
     parser.add_argument('--dp_clip', type=float, default=1.0, help='DP-SGD clipping norm')
     parser.add_argument('--dp_noise', type=float, default=0.0, help='DP-SGD noise multiplier')
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
+    parser.add_argument('--dp_constant_noise', action='store_true',
+                        help='keep DP noise multiplier constant when adapting clipping norm')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_clip_max', type=float, default=20.0, help='maximum DP-SGD clipping norm')
     parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
@@ -1186,7 +1188,8 @@ if __name__ == '__main__':
                 # new_clip = max(min(new_clip, old_clip * 1.1), old_clip * 0.9)
                 args.dp_clip = max(1.0, min(new_clip, args.dp_clip_max))
                 args.log_dp_clip = math.log(args.dp_clip)
-                args.dp_noise = dp_utils.scale_noise_to_clip(old_noise, old_clip, args.dp_clip)
+                if not args.dp_constant_noise:
+                    args.dp_noise = dp_utils.scale_noise_to_clip(old_noise, old_clip, args.dp_clip)
                 num_clients = len(deltas) or 1
                 noise_std = args.dp_noise * args.dp_noise_scale / num_clients
                 z = noise_std / args.dp_clip

--- a/main_text.py
+++ b/main_text.py
@@ -195,6 +195,8 @@ def get_args():
     parser.add_argument('--dp_clip', type=float, default=1.0, help='DP-SGD clipping norm')
     parser.add_argument('--dp_noise', type=float, default=0.0, help='DP-SGD noise multiplier')
     parser.add_argument('--dp_noise_scale', type=float, default=0.1, help='additional scaling for DP noise')
+    parser.add_argument('--dp_constant_noise', action='store_true',
+                        help='keep DP noise multiplier constant when adapting clipping norm')
     parser.add_argument('--dp_delta', type=float, default=1e-5, help='target delta for DP accountant')
     parser.add_argument('--dp_clip_max', type=float, default=2.0, help='maximum DP-SGD clipping norm')
     parser.add_argument('--dp_target_clip_fraction', type=float, default=0.1,
@@ -1151,7 +1153,8 @@ if __name__ == '__main__':
                 # new_clip = max(min(new_clip, old_clip * 1.1), old_clip * 0.9)
                 args.dp_clip = max(1.0, min(new_clip, args.dp_clip_max))
                 args.log_dp_clip = math.log(args.dp_clip)
-                args.dp_noise = dp_utils.scale_noise_to_clip(old_noise, old_clip, args.dp_clip)
+                if not args.dp_constant_noise:
+                    args.dp_noise = dp_utils.scale_noise_to_clip(old_noise, old_clip, args.dp_clip)
                 num_clients = len(deltas) or 1
                 noise_std = args.dp_noise * args.dp_noise_scale / num_clients
                 z = noise_std / args.dp_clip


### PR DESCRIPTION
## Summary
- add `--dp_constant_noise` to image and text training scripts to keep DP noise multiplier fixed
- guard adaptive clipping from rescaling `dp_noise` so base noise remains constant
- document constant-noise flag in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b828f83da8832a86350155d254d65f