### PR TITLE
Add constant DP noise option in aggregation

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -953,13 +953,17 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
     mean_scale = float(np.mean(scales)) if scales else 1.0
     logging.info('Norm stats - mean: %.4f median: %.4f', mean_norm, median_norm)
     logging.info('Scale stats - mean: %.4f max: %.4f', mean_scale, float(np.max(scales)) if scales else 1.0)
-    base_noise_std = args.dp_noise * args.dp_clip / num_clients
+    if args.dp_constant_noise:
+        base_noise_std = args.dp_noise / num_clients
+    else:
+        base_noise_std = args.dp_noise * args.dp_clip / num_clients
     logging.info(
-        'Effective noise std: %.6f (dp_noise=%.4f, dp_clip=%.4f, clients=%d)',
+        'Effective noise std: %.6f (dp_noise=%.4f, dp_clip=%.4f, clients=%d, constant_noise=%s)',
         base_noise_std,
         args.dp_noise,
         args.dp_clip,
         num_clients,
+        args.dp_constant_noise,
     )
     avg_norm_sq = 0.0
     noise_norm_sq = 0.0
@@ -987,12 +991,15 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
         noise_mult = args.dp_noise
         if noise_multipliers is not None:
             noise_mult = noise_multipliers.get(key, args.dp_noise)
-        noise = (
-            torch.randn_like(avg_update)
-            * noise_mult
-            * args.dp_clip
-            / num_clients
-        )
+        if args.dp_constant_noise:
+            noise = torch.randn_like(avg_update) * noise_mult / num_clients
+        else:
+            noise = (
+                torch.randn_like(avg_update)
+                * noise_mult
+                * args.dp_clip
+                / num_clients
+            )
         update = avg_update + noise
         updates[key] = update
         avg_norm_sq += avg_update.pow(2).sum().item()

--- a/main_text.py
+++ b/main_text.py
@@ -923,13 +923,17 @@ def aggregate_deltas(
     mean_scale = float(np.mean(scales)) if scales else 1.0
     logging.info('Norm stats - mean: %.4f median: %.4f', mean_norm, median_norm)
     logging.info('Scale stats - mean: %.4f max: %.4f', mean_scale, float(np.max(scales)) if scales else 1.0)
-    base_noise_std = args.dp_noise * args.dp_clip / num_clients
+    if args.dp_constant_noise:
+        base_noise_std = args.dp_noise / num_clients
+    else:
+        base_noise_std = args.dp_noise * args.dp_clip / num_clients
     logging.info(
-        'Effective noise std: %.6f (dp_noise=%.4f, dp_clip=%.4f, clients=%d)',
+        'Effective noise std: %.6f (dp_noise=%.4f, dp_clip=%.4f, clients=%d, constant_noise=%s)',
         base_noise_std,
         args.dp_noise,
         args.dp_clip,
         num_clients,
+        args.dp_constant_noise,
     )
     avg_norm_sq = 0.0
     noise_norm_sq = 0.0
@@ -950,13 +954,18 @@ def aggregate_deltas(
             continue
         stacked = torch.stack([d[key] for d in clipped])
         avg_update = stacked.mean(dim=0)
-        noise_mult = args.dp_noise if noise_multipliers is None else noise_multipliers.get(key, args.dp_noise)
-        noise = (
-            torch.randn_like(avg_update)
-            * noise_mult
-            * args.dp_clip
-            / num_clients
-        )
+        noise_mult = args.dp_noise
+        if noise_multipliers is not None:
+            noise_mult = noise_multipliers.get(key, args.dp_noise)
+        if args.dp_constant_noise:
+            noise = torch.randn_like(avg_update) * noise_mult / num_clients
+        else:
+            noise = (
+                torch.randn_like(avg_update)
+                * noise_mult
+                * args.dp_clip
+                / num_clients
+            )
         update = avg_update + noise
         updates[key] = update
         avg_norm_sq += avg_update.pow(2).sum().item()


### PR DESCRIPTION
## Summary
- Support `dp_constant_noise` flag in both image and text training pipelines
- Generate constant or clip-scaled DP noise per layer and log effective noise

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68ba78908214832aa25df667c0edf300