### PR TITLE
Fix step-to-avg ratio logging

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -1018,7 +1018,7 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
         eta_eff,
         'ON' if eta_eff < args.server_lr else 'off',
         step_norm,
-        step_norm / max(eta_eff * avg_norm, 1e-12),
+        step_norm / max(avg_norm, 1e-12),
     )
     for key, update in updates.items():
         if args.server_momentum == 0:

--- a/main_text.py
+++ b/main_text.py
@@ -984,7 +984,7 @@ def aggregate_deltas(
         eta_eff,
         'ON' if eta_eff < args.server_lr else 'off',
         step_norm,
-        step_norm / max(eta_eff * avg_norm, 1e-12),
+        step_norm / max(avg_norm, 1e-12),
     )
     for key, update in updates.items():
         if args.server_momentum == 0:


### PR DESCRIPTION
## Summary
- correct step-to-avg ratio in server logging for text and image training

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import logging
from types import SimpleNamespace
args = SimpleNamespace(target_step=1.0, server_lr=1.0)
unscaled_step_norm = 1.0
avg_norm = 3.8
logging.basicConfig(level=logging.INFO, format='%(message)s')
eta_cap = args.target_step / max(unscaled_step_norm, 1e-12)
eta_eff = min(args.server_lr, eta_cap)
step_norm = eta_eff * unscaled_step_norm
logging.info('server_lr(base)=%.4g eta_eff=%.4g (cap=%s) ||step||=%.4f ratio(step/avg)=%.3f',
             args.server_lr,
             eta_eff,
             'ON' if eta_eff < args.server_lr else 'off',
             step_norm,
             step_norm / max(avg_norm, 1e-12))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ba7a9e5864832a96343a426cebeb30