### PR TITLE
Refine AMP usage for stable meta-learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ When `--print_eps 1`, the current ε and δ are printed after each round.
     ```
   This applies a cosine schedule that anneals the learning rate for both DP and head optimizers to 10% of its initial value.
 * Select DP-compatible optimizers via `--optimizer`. In addition to `sgd`, `adam`, and `amsgrad`, `adamw` is supported and becomes DP-AdamW when differential privacy is enabled.
-* Enable mixed precision with `--use_amp` on CUDA devices to speed up training and reduce memory use. Gradients are scaled with `GradScaler` and unscaled before clipping so differential privacy remains intact.
+* Enable mixed precision with `--use_amp` on CUDA devices to speed up training and reduce memory use. Convolutional layers run under autocast (dtype via `--amp_dtype`) while losses and backprop stay in full precision for stability.
 * Training can stop early when global accuracy plateaus. Set `--convergence_patience` and `--convergence_delta` to monitor convergence and exit before reaching the full `--comm_round`.
 
 ### Choosing a noise multiplier for a target ε

--- a/main_image.py
+++ b/main_image.py
@@ -20,7 +20,6 @@ from model import WordEmbed
 from utils import *
 from opacus import PrivacyEngine
 from opacus.grad_sample import GradSampleModule
-from torch.cuda.amp import autocast, GradScaler
 import dp_utils
 from dp_utils import remove_dp_hooks
 import warnings
@@ -224,6 +223,8 @@ def get_args():
                         help='DP accountant to estimate the privacy budget')
     parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
     parser.add_argument('--use_amp', action='store_true', help='enable mixed precision training')
+    parser.add_argument('--amp_dtype', choices=['fp16', 'bf16'], default='fp16',
+                        help='dtype for AMP autocast')
     args = parser.parse_args()
     if args.dp_noise is not None and args.dp_noise_scale is not None:
         parser.error('--dp_noise and --dp_noise_scale are mutually exclusive')
@@ -398,7 +399,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         tl_optimizer = optim.SGD(tl_params, lr=lr, momentum=0.9, weight_decay=args.reg)
 
     use_amp = args.use_amp and args.device != 'cpu'
-    scaler = GradScaler(enabled=use_amp)
+    amp_dtype = torch.bfloat16 if args.amp_dtype == 'bf16' else torch.float16
 
     if args.dataset == 'FC100':
         X_transform_train = transforms.Compose([
@@ -578,8 +579,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
                     for j in range(args.fine_tune_steps):
                         net_new.zero_grad()
-                        with autocast(enabled=use_amp):
-                            X_out_sup, X_transformer_out_sup, out = net_new(X_total_sup)
+                        with torch.autocast('cuda', enabled=False):
+                            X_out_sup, X_transformer_out_sup, out = net_new(X_total_sup, use_amp=False)
                             losses = F.cross_entropy(out, support_labels, reduction='none')
                         losses.mean().backward()
                         with torch.no_grad():
@@ -592,81 +593,59 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                                     continue
                                 param.data.add_(-args.fine_tune_lr * param.grad)
 
-                    with autocast(enabled=use_amp):
-                        X_out_query, _, out = net_new(X_total_query)
-                        X_out_sup, X_transformer_out_sup, _ = net_new(X_total_sup)
+                    X_out_query, _, out = net_new(X_total_query, use_amp=use_amp, amp_dtype=amp_dtype)
+                    X_out_sup, X_transformer_out_sup, _ = net_new(X_total_sup, use_amp=use_amp, amp_dtype=amp_dtype)
 
-                        X_transformer_out_sup = X_transformer_out_sup.reshape([N, K, -1]).transpose(0, 1)
-                        for name, param in gmodel.named_parameters():
-                            if 'transformer' in name:
-                                param.requires_grad_(False)
-                        X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
-                        for name, param in gmodel.named_parameters():
-                            if 'transformer' in name:
-                                param.requires_grad_(True)
-                        out_sup = X_out_all[:N * K].reshape([N, K, -1]).transpose(0, 1)
-                        out_query = X_out_all[N * K:].reshape([N, Q, -1]).transpose(0, 1)
-                        #############################
-                        # Q=K here update for all-model
-                        for j in range(Q):
-                            contras_loss, similarity = InforNCE_Loss(X_transformer_out_sup[j], out_sup[(j+1) % Q],
-                                                                     tau=0.5)
-                            loss_all += contras_loss / Q * 0.1
-                        loss_all += loss_ce(out_all, y_total)
+                    X_transformer_out_sup = X_transformer_out_sup.reshape([N, K, -1]).transpose(0, 1)
+                    for name, param in gmodel.named_parameters():
+                        if 'transformer' in name:
+                            param.requires_grad_(False)
+                    X_out_all, x_all, out_all = gmodel(
+                        torch.cat([X_total_sup, X_total_query], 0),
+                        all_classify=True,
+                        use_amp=use_amp,
+                        amp_dtype=amp_dtype,
+                    )
+                    for name, param in gmodel.named_parameters():
+                        if 'transformer' in name:
+                            param.requires_grad_(True)
+                    out_sup = X_out_all[:N * K].reshape([N, K, -1]).transpose(0, 1)
+                    out_query = X_out_all[N * K:].reshape([N, Q, -1]).transpose(0, 1)
+                    #############################
+                    # Q=K here update for all-model
+                    for j in range(Q):
+                        contras_loss, similarity = InforNCE_Loss(
+                            X_transformer_out_sup[j], out_sup[(j + 1) % Q], tau=0.5
+                        )
+                        loss_all += contras_loss / Q * 0.1
+                    loss_all += loss_ce(out_all, y_total)
 
-                if use_amp:
-                    scaler.scale(loss_all).backward()
-                    dp_has_grad = _has_grads(dp_optimizer)
-                    head_has_grad = _has_grads(head_optimizer)
-                    tl_has_grad = tl_optimizer is not None and _has_grads(tl_optimizer)
-                    if dp_has_grad:
-                        scaler.unscale_(dp_optimizer)
-                        if hasattr(dp_optimizer, 'params'):
-                            for param in dp_optimizer.params:
-                                if getattr(param, 'grad_sample', None) is not None:
-                                    param.grad_sample = param.grad_sample.float()
-                                    param.grad_sample /= scaler.get_scale()
-                    if head_has_grad:
-                        scaler.unscale_(head_optimizer)
-                    if tl_has_grad:
-                        scaler.unscale_(tl_optimizer)
-                    grad_norm = torch.nn.utils.clip_grad_norm_(gmodel.parameters(), max_norm)
-                    last_loss = loss_all.item()
-                    print(f'batch loss: {last_loss:.4f}, grad_norm: {grad_norm:.4f}')
-                    if torch.isnan(torch.tensor(grad_norm)) or torch.isnan(loss_all.detach()):
-                        print('warning: NaN detected in loss or gradients')
-                    if args.dp_mode == 'local':
-                        for name, param in dp_named_params:
-                            if param.grad is None:
-                                continue
-                            grad_norm = param.grad.detach().norm(2).item()
-                            prev = args.grad_norms_ma.get(name, grad_norm)
-                            args.grad_norms_ma[name] = grad_ma_decay * prev + (1 - grad_ma_decay) * grad_norm
-                    if dp_has_grad:
-                        scaler.step(dp_optimizer)
-                    if head_has_grad:
-                        scaler.step(head_optimizer)
-                    if tl_has_grad:
-                        scaler.step(tl_optimizer)
-                    scaler.update()
-                else:
-                    loss_all.backward()
-                    grad_norm = torch.nn.utils.clip_grad_norm_(gmodel.parameters(), max_norm)
-                    last_loss = loss_all.item()
-                    print(f'batch loss: {last_loss:.4f}, grad_norm: {grad_norm:.4f}')
-                    if torch.isnan(torch.tensor(grad_norm)) or torch.isnan(loss_all.detach()):
-                        print('warning: NaN detected in loss or gradients')
-                    if args.dp_mode == 'local':
-                        for name, param in dp_named_params:
-                            if param.grad is None:
-                                continue
-                            grad_norm = param.grad.detach().norm(2).item()
-                            prev = args.grad_norms_ma.get(name, grad_norm)
-                            args.grad_norms_ma[name] = grad_ma_decay * prev + (1 - grad_ma_decay) * grad_norm
+                loss_all.backward()
+                dp_has_grad = _has_grads(dp_optimizer)
+                head_has_grad = _has_grads(head_optimizer)
+                tl_has_grad = tl_optimizer is not None and _has_grads(tl_optimizer)
+                if dp_has_grad and hasattr(dp_optimizer, 'params'):
+                    for param in dp_optimizer.params:
+                        if getattr(param, 'grad_sample', None) is not None:
+                            param.grad_sample = param.grad_sample.float()
+                grad_norm = torch.nn.utils.clip_grad_norm_(gmodel.parameters(), max_norm)
+                last_loss = loss_all.item()
+                print(f'batch loss: {last_loss:.4f}, grad_norm: {grad_norm:.4f}')
+                if torch.isnan(torch.tensor(grad_norm)) or torch.isnan(loss_all.detach()):
+                    print('warning: NaN detected in loss or gradients')
+                if args.dp_mode == 'local':
+                    for name, param in dp_named_params:
+                        if param.grad is None:
+                            continue
+                        grad_norm = param.grad.detach().norm(2).item()
+                        prev = args.grad_norms_ma.get(name, grad_norm)
+                        args.grad_norms_ma[name] = grad_ma_decay * prev + (1 - grad_ma_decay) * grad_norm
+                if dp_has_grad:
                     dp_optimizer.step()
+                if head_has_grad:
                     head_optimizer.step()
-                    if tl_optimizer is not None:
-                        tl_optimizer.step()
+                if tl_has_grad:
+                    tl_optimizer.step()
                 ############################
     
                     for name, param in gmodel.named_parameters():
@@ -675,8 +654,12 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     if isinstance(gmodel, GradSampleModule):
                         gmodel.disable_hooks()
                     with torch.no_grad():
-                        with autocast(enabled=use_amp):
-                            X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
+                        X_out_all, x_all, out_all = gmodel(
+                            torch.cat([X_total_sup, X_total_query], 0),
+                            all_classify=True,
+                            use_amp=use_amp,
+                            amp_dtype=amp_dtype,
+                        )
                     if isinstance(gmodel, GradSampleModule):
                         gmodel.enable_hooks()
                     for name, param in gmodel.named_parameters():
@@ -722,8 +705,11 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
                 if use_logistic:
                     with torch.no_grad():
-                        with autocast(enabled=use_amp):
-                            X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0))
+                        X_out_all, x_all, out_all = gmodel(
+                            torch.cat([X_total_sup, X_total_query], 0),
+                            use_amp=use_amp,
+                            amp_dtype=amp_dtype,
+                        )
                         X_out_sup = X_out_all[:N * K]
                         X_out_query = X_out_all[N * K:]
 
@@ -731,9 +717,10 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     query_features = torch.nan_to_num(l2_normalize(X_out_query), nan=0.0, posinf=0.0, neginf=0.0).float()
 
                     clf = LogisticRegression(support_features.size(1), N).to(support_features.device).float()
-                    with autocast(enabled=False):
+                    with torch.autocast('cuda', enabled=False):
                         clf.fit(support_features, support_labels, max_iter=1000)
-                        out = clf.predict_proba(query_features)
+                        with torch.inference_mode():
+                            out = clf.predict_proba(query_features)
 
                     acc_train = (torch.argmax(out, -1) == query_labels).float().mean().item()
                     max_value, index = torch.max(out, -1)

--- a/main_text.py
+++ b/main_text.py
@@ -20,7 +20,6 @@ from model import WordEmbed
 from utils import *
 from opacus import PrivacyEngine
 from opacus.grad_sample import GradSampleModule
-from torch.cuda.amp import autocast, GradScaler
 import dp_utils
 from dp_utils import remove_dp_hooks
 import warnings
@@ -216,6 +215,8 @@ def get_args():
                         help='DP accountant to estimate the privacy budget')
     parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
     parser.add_argument('--use_amp', action='store_true', help='enable mixed precision training')
+    parser.add_argument('--amp_dtype', choices=['fp16', 'bf16'], default='fp16',
+                        help='dtype for AMP autocast')
     args = parser.parse_args()
     if args.dp_noise is not None and args.dp_noise_scale is not None:
         parser.error('--dp_noise and --dp_noise_scale are mutually exclusive')
@@ -382,7 +383,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
         tl_optimizer = optim.SGD(tl_params, lr=lr, momentum=0.9, weight_decay=args.reg)
 
     use_amp = args.use_amp and args.device != 'cpu'
-    scaler = GradScaler(enabled=use_amp)
+    amp_dtype = torch.bfloat16 if args.amp_dtype == 'bf16' else torch.float16
 
     if args.dataset == 'FC100':
         X_transform_train = transforms.Compose([
@@ -558,8 +559,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
                     for j in range(args.fine_tune_steps):
                         net_new.zero_grad()
-                        with autocast(enabled=use_amp):
-                            X_out_sup, X_transformer_out_sup, out = net_new(X_total_sup)
+                        with torch.autocast('cuda', enabled=False):
+                            X_out_sup, X_transformer_out_sup, out = net_new(X_total_sup, use_amp=False)
                             losses = F.cross_entropy(out, support_labels, reduction='none')
                         losses.mean().backward()
                         with torch.no_grad():
@@ -572,73 +573,54 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                                     continue
                                 param.data.add_(-args.fine_tune_lr * param.grad)
 
-                    with autocast(enabled=use_amp):
-                        X_out_query, _, out = net_new(X_total_query)
-                        X_out_sup, X_transformer_out_sup, _ = net_new(X_total_sup)
+                    X_out_query, _, out = net_new(X_total_query, use_amp=use_amp, amp_dtype=amp_dtype)
+                    X_out_sup, X_transformer_out_sup, _ = net_new(X_total_sup, use_amp=use_amp, amp_dtype=amp_dtype)
 
-                        X_transformer_out_sup = X_transformer_out_sup.reshape([N, K, -1]).transpose(0, 1)
-                        for name, param in gmodel.named_parameters():
-                            if 'transformer' in name:
-                                param.requires_grad_(False)
-                        X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
-                        for name, param in gmodel.named_parameters():
-                            if 'transformer' in name:
-                                param.requires_grad_(True)
-                        out_sup = X_out_all[:N * K].reshape([N, K, -1]).transpose(0, 1)
-                        out_query = X_out_all[N * K:].reshape([N, Q, -1]).transpose(0, 1)
-                        #############################
-                        # Q=K here update for all-model
-                        for j in range(Q):
-                            contras_loss, similarity = InforNCE_Loss(X_transformer_out_sup[j], out_sup[(j+1)%Q],
-                                                                     tau=0.5)
-                            loss_all += contras_loss / Q *0.1
-                        loss_all += loss_ce(out_all, y_total)
+                    X_transformer_out_sup = X_transformer_out_sup.reshape([N, K, -1]).transpose(0, 1)
+                    for name, param in gmodel.named_parameters():
+                        if 'transformer' in name:
+                            param.requires_grad_(False)
+                    X_out_all, x_all, out_all = gmodel(
+                        torch.cat([X_total_sup, X_total_query], 0),
+                        all_classify=True,
+                        use_amp=use_amp,
+                        amp_dtype=amp_dtype,
+                    )
+                    for name, param in gmodel.named_parameters():
+                        if 'transformer' in name:
+                            param.requires_grad_(True)
+                    out_sup = X_out_all[:N * K].reshape([N, K, -1]).transpose(0, 1)
+                    out_query = X_out_all[N * K:].reshape([N, Q, -1]).transpose(0, 1)
+                    #############################
+                    # Q=K here update for all-model
+                    for j in range(Q):
+                        contras_loss, similarity = InforNCE_Loss(
+                            X_transformer_out_sup[j], out_sup[(j + 1) % Q], tau=0.5
+                        )
+                        loss_all += contras_loss / Q *0.1
+                    loss_all += loss_ce(out_all, y_total)
 
-                if use_amp:
-                    scaler.scale(loss_all).backward()
-                    scaler.unscale_(dp_optimizer)
-                    if hasattr(dp_optimizer, 'params'):
-                        for _, param in dp_named_params:
-                            if hasattr(param, 'grad_sample') and param.grad_sample is not None:
-                                param.grad_sample = (param.grad_sample / scaler.get_scale()).float()
-                    scaler.unscale_(head_optimizer)
-                    if tl_optimizer is not None:
-                        scaler.unscale_(tl_optimizer)
-                    grad_norm = torch.nn.utils.clip_grad_norm_(gmodel.parameters(), max_norm)
-                    last_loss = loss_all.item()
-                    print(f'batch loss: {last_loss:.4f}, grad_norm: {grad_norm:.4f}')
-                    if torch.isnan(torch.tensor(grad_norm)) or torch.isnan(loss_all.detach()):
-                        print('warning: NaN detected in loss or gradients')
-                    if args.dp_mode == 'local':
-                        for name, param in dp_named_params:
-                            if param.grad is None:
-                                continue
-                            grad_norm = param.grad.detach().norm(2).item()
-                            prev = args.grad_norms_ma.get(name, grad_norm)
-                            args.grad_norms_ma[name] = grad_ma_decay * prev + (1 - grad_ma_decay) * grad_norm
-                    scaler.step(dp_optimizer)
-                    scaler.step(head_optimizer)
-                    if tl_optimizer is not None:
-                        scaler.step(tl_optimizer)
-                    scaler.update()
-                else:
-                    loss_all.backward()
-                    grad_norm = torch.nn.utils.clip_grad_norm_(gmodel.parameters(), max_norm)
-                    last_loss = loss_all.item()
-                    print(f'batch loss: {last_loss:.4f}, grad_norm: {grad_norm:.4f}')
-                    if torch.isnan(torch.tensor(grad_norm)) or torch.isnan(loss_all.detach()):
-                        print('warning: NaN detected in loss or gradients')
-                    if args.dp_mode == 'local':
-                        for name, param in dp_named_params:
-                            if param.grad is None:
-                                continue
-                            grad_norm = param.grad.detach().norm(2).item()
-                            prev = args.grad_norms_ma.get(name, grad_norm)
-                            args.grad_norms_ma[name] = grad_ma_decay * prev + (1 - grad_ma_decay) * grad_norm
-                    dp_optimizer.step()
-                    head_optimizer.step()
-                    if tl_optimizer is not None:
-                        tl_optimizer.step()
+                loss_all.backward()
+                if hasattr(dp_optimizer, 'params'):
+                    for _, param in dp_named_params:
+                        if hasattr(param, 'grad_sample') and param.grad_sample is not None:
+                            param.grad_sample = param.grad_sample.float()
+                grad_norm = torch.nn.utils.clip_grad_norm_(gmodel.parameters(), max_norm)
+                last_loss = loss_all.item()
+                print(f'batch loss: {last_loss:.4f}, grad_norm: {grad_norm:.4f}')
+                if torch.isnan(torch.tensor(grad_norm)) or torch.isnan(loss_all.detach()):
+                    print('warning: NaN detected in loss or gradients')
+                if args.dp_mode == 'local':
+                    for name, param in dp_named_params:
+                        if param.grad is None:
+                            continue
+                        grad_norm = param.grad.detach().norm(2).item()
+                        prev = args.grad_norms_ma.get(name, grad_norm)
+                        args.grad_norms_ma[name] = grad_ma_decay * prev + (1 - grad_ma_decay) * grad_norm
+                dp_optimizer.step()
+                head_optimizer.step()
+                if tl_optimizer is not None:
+                    tl_optimizer.step()
                 ############################
     
                     for name, param in gmodel.named_parameters():
@@ -647,8 +629,12 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     if isinstance(gmodel, GradSampleModule):
                         gmodel.disable_hooks()
                     with torch.no_grad():
-                        with autocast(enabled=use_amp):
-                            X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0), all_classify=True)
+                        X_out_all, x_all, out_all = gmodel(
+                            torch.cat([X_total_sup, X_total_query], 0),
+                            all_classify=True,
+                            use_amp=use_amp,
+                            amp_dtype=amp_dtype,
+                        )
                     if isinstance(gmodel, GradSampleModule):
                         gmodel.enable_hooks()
                     for name, param in gmodel.named_parameters():
@@ -691,8 +677,11 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     
                 if use_logistic:
                     with torch.no_grad():
-                        with autocast(enabled=use_amp):
-                            X_out_all, x_all, out_all = gmodel(torch.cat([X_total_sup, X_total_query], 0))
+                        X_out_all, x_all, out_all = gmodel(
+                            torch.cat([X_total_sup, X_total_query], 0),
+                            use_amp=use_amp,
+                            amp_dtype=amp_dtype,
+                        )
                         X_out_sup = X_out_all[:N * K]
                         X_out_query = X_out_all[N * K:]
 
@@ -700,9 +689,10 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     query_features = torch.nan_to_num(l2_normalize(X_out_query), nan=0.0, posinf=0.0, neginf=0.0).float()
 
                     clf = LogisticRegression(support_features.size(1), N).to(support_features.device).float()
-                    with autocast(enabled=False):
+                    with torch.autocast('cuda', enabled=False):
                         clf.fit(support_features, support_labels, max_iter=1000)
-                        out = clf.predict_proba(query_features)
+                        with torch.inference_mode():
+                            out = clf.predict_proba(query_features)
 
                     acc_train = (torch.argmax(out, -1) == query_labels).float().mean().item()
                     max_value, index = torch.max(out, -1)

--- a/model.py
+++ b/model.py
@@ -1002,27 +1002,40 @@ class ModelFed_Adp(nn.Module):
         except:
             raise ("Invalid model name. Check the config file and pass one of: resnet18 or resnet50")
 
-    def forward(self, x_ori, all_classify=False):
+    def forward(self, x_ori, all_classify=False, use_amp=False, amp_dtype=torch.float16):
+        """Forward pass with optional autocast for feature extraction.
+
+        Parameters
+        ----------
+        x_ori : torch.Tensor
+            Input batch.
+        all_classify : bool, optional
+            If ``True``, compute logits for all classes using ``all_classify``.
+        use_amp : bool, optional
+            Enable AMP autocast for the feature extractor.
+        amp_dtype : torch.dtype, optional
+            Precision to use for autocast when ``use_amp`` is ``True``.
+
+        Returns
+        -------
+        tuple(torch.Tensor, torch.Tensor, torch.Tensor)
+            Feature embeddings, intermediate representations and logits.
+        """
         if self.transform_layer is not None:
             x_ori = self.transform_layer(x_ori)
-        h = self.features(x_ori)
+        with torch.autocast('cuda', dtype=amp_dtype, enabled=use_amp):
+            h = self.features(x_ori)
 
-        # print("h before:", h)
-        # print("h size:", h.size())
         ebd = h.view(h.size(0), -1)
-        # print("h after:", h)
-        #x = self.l1(h)
-        #x = F.relu(x)
-        #x = self.l2(x)
-
-        if not all_classify:
-            x = self.transformer(ebd.unsqueeze(1)).squeeze(1)
-            y = self.few_classify(x)
-        else:
-            x = self.l1(ebd)
-            x = F.relu(x)
-            x = self.l2(x)
-            y = self.all_classify(x)
+        with torch.autocast('cuda', enabled=False):
+            if not all_classify:
+                x = self.transformer(ebd.unsqueeze(1)).squeeze(1)
+                y = self.few_classify(x)
+            else:
+                x = self.l1(ebd)
+                x = F.relu(x)
+                x = self.l2(x)
+                y = self.all_classify(x)
         return ebd, x, y
 
 


### PR DESCRIPTION
## Summary
- Add `--amp_dtype` and run convolutional layers under autocast while keeping loss/backward in FP32
- Disable autocast for fine-tune steps and logistic probes to preserve meta signal
- Document mixed-precision approach in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ba9d535710832a9cc286091401c3f1