### PR TITLE
Cast flattened embeddings to float32 to avoid dtype mismatches

### DIFF
--- a/model.py
+++ b/model.py
@@ -1026,7 +1026,7 @@ class ModelFed_Adp(nn.Module):
         with torch.autocast('cuda', dtype=amp_dtype, enabled=use_amp):
             h = self.features(x_ori)
 
-        ebd = h.view(h.size(0), -1)
+        ebd = h.view(h.size(0), -1).float()
         with torch.autocast('cuda', enabled=False):
             if not all_classify:
                 x = self.transformer(ebd.unsqueeze(1)).squeeze(1)


### PR DESCRIPTION
## Summary
- Cast flattened feature tensor to `float32` before transformer and classifier layers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- Ran manual forward pass to confirm embeddings and logits are `float32`


------
https://chatgpt.com/codex/tasks/task_e_68baa0964318832a809d058bb234bb42