### PR TITLE
Use noiseless norm for server step cap

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -996,16 +996,17 @@ def aggregate_deltas(global_w, deltas, args, noise_multipliers=None, reset_bn=Fa
     noise_norm = noise_norm_sq ** 0.5
     unscaled_step_norm = step_norm_sq ** 0.5
     logging.info('||avg||=%.4f ||noise||=%.4f ||u||=%.4f', avg_norm, noise_norm, unscaled_step_norm)
-    eta_cap = args.target_step / max(unscaled_step_norm, 1e-12)
+    eta_cap = args.target_step / max(avg_norm, 1e-12)
     eta_eff = min(args.server_lr, eta_cap)
     step_norm = eta_eff * unscaled_step_norm
     logging.info(
-        'server_lr(base)=%.4g eta_eff=%.4g (cap=%s) ||step||=%.4f ratio(step/avg)=%.3f',
+        'server_lr(base)=%.4g eta_eff=%.4g (cap=%s) ||step||=%.4f ratio(step/avg)=%.3f ||u||=%.4f',
         args.server_lr,
         eta_eff,
         'ON' if eta_eff < args.server_lr else 'off',
         step_norm,
         step_norm / max(avg_norm, 1e-12),
+        unscaled_step_norm,
     )
     for key, update in updates.items():
         if args.server_momentum == 0:

--- a/main_text.py
+++ b/main_text.py
@@ -965,16 +965,17 @@ def aggregate_deltas(
     noise_norm = noise_norm_sq ** 0.5
     unscaled_step_norm = step_norm_sq ** 0.5
     logging.info('||avg||=%.4f ||noise||=%.4f ||u||=%.4f', avg_norm, noise_norm, unscaled_step_norm)
-    eta_cap = args.target_step / max(unscaled_step_norm, 1e-12)
+    eta_cap = args.target_step / max(avg_norm, 1e-12)
     eta_eff = min(args.server_lr, eta_cap)
     step_norm = eta_eff * unscaled_step_norm
     logging.info(
-        'server_lr(base)=%.4g eta_eff=%.4g (cap=%s) ||step||=%.4f ratio(step/avg)=%.3f',
+        'server_lr(base)=%.4g eta_eff=%.4g (cap=%s) ||step||=%.4f ratio(step/avg)=%.3f ||u||=%.4f',
         args.server_lr,
         eta_eff,
         'ON' if eta_eff < args.server_lr else 'off',
         step_norm,
         step_norm / max(avg_norm, 1e-12),
+        unscaled_step_norm,
     )
     for key, update in updates.items():
         if args.server_momentum == 0:


### PR DESCRIPTION
## Summary
- compute `eta_cap` from the noiseless average update
- log noisy and noiseless norms for diagnostics in delta aggregation

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bd15c9f824832a92717581a8da6b28