### PR TITLE
Handle per-layer noise ratios in privacy accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The repository now includes optional support for a **personalised transformation
   * `--dp_noise`: fixed noise multiplier (default) **or** `--dp_noise_scale` to scale noise with the clip via `sigma = scale * clip`
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)
   * `--print_eps`: output the current ε after each communication round when set to `1`
+  * ε uses the minimum σ<sub>l</sub>/C<sub>l</sub> across layers when noise or clip ratios differ
 
 Examples:
 
@@ -65,7 +66,7 @@ python main_image.py --dataset miniImageNet --dp_mode off
 # FedAvgM with server learning rate
 python main_image.py --dataset miniImageNet --server_momentum 0.9 --server_lr 0.1
 ```
-When `--print_eps 1`, the current ε and δ are printed after each round.
+When `--print_eps 1`, the current ε and δ are printed after each round using the minimum noise-to-clip ratio across layers.
 
 * Enable server momentum with `--server_momentum <m>` and set the server learning rate with `--server_lr <lr>` to use FedAvgM for faster convergence. A good starting point is `lr ≈ 1 - m`.
 * Cap the server update norm with `--target_step <s>` to limit the L2 norm of the aggregated step after scaling. Values around `1.0` work well; tune by monitoring the logged `||u||` and set `s` either as an absolute norm or as a fraction of the typical signal norm.

--- a/main_image.py
+++ b/main_image.py
@@ -225,7 +225,12 @@ def get_args():
     parser.add_argument('--dp_mode', choices=['local', 'server', 'off'], default='server')
     parser.add_argument('--dp_accountant', choices=['rdp', 'prv'], default='rdp',
                         help='DP accountant to estimate the privacy budget')
-    parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
+    parser.add_argument(
+        '--print_eps',
+        type=int,
+        default=0,
+        help='print final privacy budget (uses minimum noise/clip ratio across layers)',
+    )
     parser.add_argument('--use_amp', action='store_true', help='enable mixed precision training')
     parser.add_argument('--amp_dtype', choices=['fp16', 'bf16'], default='fp16',
                         help='dtype for AMP autocast')
@@ -1196,9 +1201,14 @@ if __name__ == '__main__':
             elif args.dp_mode == 'server':
                 dp_steps += 1
             if args.dp_mode != 'off':
+                ratios = [
+                    noise_multipliers[name] / layer_clips.get(name, args.dp_clip)
+                    for name in noise_multipliers
+                ]
+                noise_for_eps = args.dp_noise if len(set(ratios)) <= 1 else min(ratios)
                 epsilon = dp_utils.compute_epsilon(
                     dp_steps,
-                    args.dp_noise,
+                    noise_for_eps,
                     args.dp_delta,
                     accountant=args.dp_accountant,
                     sampling_rate=len(participating_ids) / args.n_parties,

--- a/main_text.py
+++ b/main_text.py
@@ -217,7 +217,12 @@ def get_args():
     parser.add_argument('--dp_mode', choices=['local', 'server', 'off'], default='server')
     parser.add_argument('--dp_accountant', choices=['rdp', 'prv'], default='rdp',
                         help='DP accountant to estimate the privacy budget')
-    parser.add_argument('--print_eps', type=int, default=0, help='print final privacy budget')
+    parser.add_argument(
+        '--print_eps',
+        type=int,
+        default=0,
+        help='print final privacy budget (uses minimum noise/clip ratio across layers)',
+    )
     parser.add_argument('--use_amp', action='store_true', help='enable mixed precision training')
     parser.add_argument('--amp_dtype', choices=['fp16', 'bf16'], default='fp16',
                         help='dtype for AMP autocast')
@@ -1165,9 +1170,14 @@ if __name__ == '__main__':
             elif args.dp_mode == 'server':
                 dp_steps += 1
             if args.dp_mode != 'off':
+                ratios = [
+                    noise_multipliers[name] / layer_clips.get(name, args.dp_clip)
+                    for name in noise_multipliers
+                ]
+                noise_for_eps = args.dp_noise if len(set(ratios)) <= 1 else min(ratios)
                 epsilon = dp_utils.compute_epsilon(
                     dp_steps,
-                    args.dp_noise,
+                    noise_for_eps,
                     args.dp_delta,
                     accountant=args.dp_accountant,
                     sampling_rate=len(participating_ids) / args.n_parties,


### PR DESCRIPTION
## Summary
- compute epsilon using the smallest noise-to-clip ratio when layer ratios differ
- clarify privacy budget flag to mention per-layer accounting
- document minimum sigma/clip ratio behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bd2d062894832aae88e0032d9e6748