### PR TITLE
Use minimum noise multiplier for epsilon

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The repository now includes optional support for a **personalised transformation
   * `--dp_noise`: fixed noise multiplier (default) **or** `--dp_noise_scale` to scale noise with the clip via `sigma = scale * clip`
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)
   * `--print_eps`: output the current ε after each communication round when set to `1`
-  * ε uses the minimum σ<sub>l</sub>/C<sub>l</sub> across layers when noise or clip ratios differ
+  * ε uses the minimum σ<sub>l</sub> across layers when noise multipliers differ
 
 Examples:
 

--- a/main_image.py
+++ b/main_image.py
@@ -1201,11 +1201,8 @@ if __name__ == '__main__':
             elif args.dp_mode == 'server':
                 dp_steps += 1
             if args.dp_mode != 'off':
-                ratios = [
-                    noise_multipliers[name] / layer_clips.get(name, args.dp_clip)
-                    for name in noise_multipliers
-                ]
-                noise_for_eps = args.dp_noise if len(set(ratios)) <= 1 else min(ratios)
+                noise_levels = list(noise_multipliers.values())
+                noise_for_eps = args.dp_noise if len(set(noise_levels)) <= 1 else min(noise_levels)
                 epsilon = dp_utils.compute_epsilon(
                     dp_steps,
                     noise_for_eps,

--- a/main_text.py
+++ b/main_text.py
@@ -1170,11 +1170,8 @@ if __name__ == '__main__':
             elif args.dp_mode == 'server':
                 dp_steps += 1
             if args.dp_mode != 'off':
-                ratios = [
-                    noise_multipliers[name] / layer_clips.get(name, args.dp_clip)
-                    for name in noise_multipliers
-                ]
-                noise_for_eps = args.dp_noise if len(set(ratios)) <= 1 else min(ratios)
+                noise_levels = list(noise_multipliers.values())
+                noise_for_eps = args.dp_noise if len(set(noise_levels)) <= 1 else min(noise_levels)
                 epsilon = dp_utils.compute_epsilon(
                     dp_steps,
                     noise_for_eps,


### PR DESCRIPTION
## Summary
- Determine epsilon using minimum per-layer noise multiplier instead of clip ratios
- Update DP epsilon documentation for new noise selection logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bd31435b20832aaee104ec960cc45c