### PR TITLE
Normalize block names when aggregating deltas

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -939,10 +939,18 @@ def aggregate_deltas(global_w, deltas, args, layer_clips, noise_multipliers=None
     mean_scale = float(total_clipped / (total_norm + 1e-12))
     layer_mean_scales = {k: float(np.mean(v)) for k, v in layer_scales.items()}
     layer_mean_norms = {k: float(np.mean(v)) for k, v in layer_norms.items()}
+
+    def _strip_prefix(n: str) -> str:
+        parts = n.split('.')
+        while parts and not parts[0].startswith('layer'):
+            parts = parts[1:]
+        return '.'.join(parts)
+
     block_scales = {f'layer{i}': [] for i in range(1, 5)}
     for name, s in layer_mean_scales.items():
+        norm_name = _strip_prefix(name)
         for block in block_scales:
-            if name.startswith(block):
+            if norm_name.startswith(block):
                 block_scales[block].append(s)
                 break
     block_medians = {k: float(np.median(v)) if v else 0.0 for k, v in block_scales.items()}

--- a/main_text.py
+++ b/main_text.py
@@ -904,8 +904,25 @@ def aggregate_deltas(
     median_norm = float(np.median(norms)) if norms else 0.0
     mean_scale = float(np.mean(scales)) if scales else 1.0
     layer_mean_scales = {k: float(np.mean(v)) for k, v in layer_scales.items()}
+
+    def _strip_prefix(n: str) -> str:
+        parts = n.split('.')
+        while parts and not parts[0].startswith('layer'):
+            parts = parts[1:]
+        return '.'.join(parts)
+
+    block_scales = {f'layer{i}': [] for i in range(1, 5)}
+    for name, s in layer_mean_scales.items():
+        norm_name = _strip_prefix(name)
+        for block in block_scales:
+            if norm_name.startswith(block):
+                block_scales[block].append(s)
+                break
+    block_medians = {k: float(np.median(v)) if v else 0.0 for k, v in block_scales.items()}
+
     logging.info('Norm stats - mean: %.4f median: %.4f', mean_norm, median_norm)
     logging.info('Scale stats - mean: %.4f max: %.4f', mean_scale, float(np.max(scales)) if scales else 1.0)
+    logging.info('Block median scales: %s', ' '.join(f'{k}:{v:.3f}' for k, v in block_medians.items()))
     avg_norm_sq = 0.0
     noise_norm_sq = 0.0
     updates = {}


### PR DESCRIPTION
## Summary
- Normalize parameter names in `aggregate_deltas` to ignore leading wrappers like `module.` before block checks
- Compute block median scales using normalized names to aggregate parameters correctly
- Log block medians for both image and text aggregation paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- Verified block median scales via a small aggregation run for both image and text paths

------
https://chatgpt.com/codex/tasks/task_e_68be42bd755c832a9b9d839d8cfd00b4