### PR TITLE
Implement per-layer DP clip floors and adaptation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ The repository now includes optional support for a **personalised transformation
   * `server`: clip and noise client updates on the server.
   * `off`: disable differential privacy.
   * `--dp_clip`: clipping norm (default `1.0`)
-  * `--dp_clip_min` / `--dp_clip_max`: bounds for adaptive clipping (defaults `1.0` / `20.0` for images, `2.0` max for text)
+  * `--dp_k_min`: floor multiplier for per-layer norms (default `0.2`)
+  * `--dp_init_scale`: initial clip scaling (default `0.6`)
+  * `--dp_clip_max`: maximum clip (default `0.8`)
   * `--dp_target_mean_scale`: desired mean clipping scale (default `0.6`)
   * `--dp_adapt_gain`: adaptation gain (default `0.1`)
   * `--dp_adapt_period`: rounds between clip adaptations (default `3`)
-  * `--dp_deadband`: tolerance around the target scale before adapting (default `0.03`)
   * `--dp_bootstrap`: bootstrap clip from the first round's median norm (default `True`)
   * `--dp_noise`: fixed noise multiplier (default) **or** `--dp_noise_scale` to scale noise with the clip via `sigma = scale * clip`
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)

--- a/main_image.py
+++ b/main_image.py
@@ -29,7 +29,9 @@ warnings.filterwarnings('ignore')
 
 layer_clips: dict[str, float] = {}
 scale_ema: dict[str, float] = {}
-layer_norms: dict[str, float] = {}
+norm_ema: dict[str, float] = {}
+clip_min: dict[str, float] = {}
+log_clip: dict[str, float] = {}
 noise_multipliers: dict[str, float] = {}
 
 from collections import defaultdict
@@ -207,8 +209,9 @@ def get_args():
     parser.add_argument('--use_transform_layer', type=int, default=0,
                         help='enable personalized transformation layer')
     parser.add_argument('--dp_clip', type=float, default=1.0, help='DP-SGD clipping norm')
-    parser.add_argument('--dp_clip_min', type=float, default=1.0, help='minimum DP-SGD clipping norm')
-    parser.add_argument('--dp_clip_max', type=float, default=20.0, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--dp_k_min', type=float, default=0.2, help='minimum clip multiplier relative to norm EMA')
+    parser.add_argument('--dp_init_scale', type=float, default=0.6, help='initial clip scaling')
+    parser.add_argument('--dp_clip_max', type=float, default=0.8, help='maximum DP-SGD clipping norm')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--dp_noise', type=float, default=None, help='DP-SGD noise multiplier')
     group.add_argument('--dp_noise_scale', type=float, default=None, help='scale for DP noise as sigma = scale * clip')
@@ -245,7 +248,7 @@ def get_args():
         args.dp_noise_init = args.dp_noise
     elif args.dp_noise is None:
         args.dp_noise = 0.0
-    args.dp_clip = min(max(args.dp_clip, args.dp_clip_min), args.dp_clip_max)
+    args.dp_clip = min(max(args.dp_clip, 1e-4), args.dp_clip_max)
     args.log_dp_clip = math.log(max(1.0, args.dp_clip))
     return args
 
@@ -1323,40 +1326,26 @@ if __name__ == '__main__':
                     global_w, deltas, args, layer_clips, noise_multipliers
                 )
                 logging.info('Aggregate mean scale: %.4f', mean_scale)
-                if not layer_norms:
-                    layer_norms.update(layer_mean_norms)
                 decay = 0.9
+                for name, norm in layer_mean_norms.items():
+                    norm_ema[name] = decay * norm_ema.get(name, norm) + (1 - decay) * norm
+                    clip_min[name] = max(1e-4, args.dp_k_min * norm_ema[name])
                 for name, s in layer_mean_scales.items():
                     scale_ema[name] = decay * scale_ema.get(name, s) + (1 - decay) * s
                 if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
-                    for name, norm_l in layer_norms.items():
-                        layer_clips[name] = max(args.dp_target_mean_scale * norm_l, args.dp_clip_min)
+                    for name in norm_ema:
+                        layer_clips[name] = float(np.clip(args.dp_init_scale * norm_ema[name], clip_min[name], args.dp_clip_max))
+                        log_clip[name] = math.log(layer_clips[name])
                     args.bootstrap_done = True
-                target = args.dp_target_mean_scale
                 if (round + 1) % args.dp_adapt_period == 0:
-                    updated = []
-                    for name, s_inst in layer_mean_scales.items():
-                        s_ema = scale_ema.get(name, s_inst)
-                        if abs(s_inst - target) < args.dp_deadband:
-                            continue
-                        e_ema = s_ema - target
-                        e_inst = s_inst - target
-                        e = e_inst if np.sign(e_ema) != np.sign(e_inst) else e_ema
-                        delta = -args.dp_adapt_gain * e
-                        delta = float(np.clip(delta, -math.log(1.2), math.log(1.2)))
-                        old_clip = max(layer_clips[name], args.dp_clip_min)
-                        log_clip = math.log(old_clip)
-                        log_clip = min(max(log_clip + delta, math.log(args.dp_clip_min)), math.log(args.dp_clip_max))
-                        new_clip = math.exp(log_clip)
-                        if new_clip != old_clip:
-                            layer_clips[name] = new_clip
-                            updated.append((name, old_clip, new_clip, s_inst, s_ema))
-                    if updated:
-                        logging.info('Layer-wise mean-scale control:')
-                        for name, old_clip, new_clip, s_inst, s_ema in updated:
-                            logging.info('%s — s*: %.3f, s̄: %.3f (EMA %.3f), clip: %.2f → %.2f',
-                                         name, target, s_inst, s_ema, old_clip, new_clip)
-                        logging.info('Current layer clips: %s', layer_clips)
+                    for name in layer_mean_scales:
+                        log_clip[name] = log_clip.get(name, math.log(layer_clips.get(name, args.dp_clip)))
+                        log_clip[name] += args.dp_adapt_gain * (args.dp_target_mean_scale - scale_ema[name])
+                        log_clip[name] = min(max(log_clip[name], math.log(clip_min[name])), math.log(args.dp_clip_max))
+                        layer_clips[name] = math.exp(log_clip[name])
+                logging.info('clip_min: %s', clip_min)
+                logging.info('layer_clips: %s', layer_clips)
+                logging.info('layer_mean_scales: %s', layer_mean_scales)
             else:
                 total_data_points = sum(len(net_dataidx_map[r]) for r in participating_ids)
                 fed_avg_freqs = [len(net_dataidx_map[r]) / total_data_points for r in participating_ids]

--- a/main_text.py
+++ b/main_text.py
@@ -29,6 +29,9 @@ warnings.filterwarnings('ignore')
 
 layer_clips: dict[str, float] = {}
 scale_ema: dict[str, float] = {}
+norm_ema: dict[str, float] = {}
+clip_min: dict[str, float] = {}
+log_clip: dict[str, float] = {}
 noise_multipliers: dict[str, float] = {}
 
 from collections import defaultdict
@@ -196,8 +199,9 @@ def get_args():
     parser.add_argument('--use_transform_layer', type=int, default=0,
                         help='enable personalized transformation layer')
     parser.add_argument('--dp_clip', type=float, default=1.0, help='DP-SGD clipping norm')
-    parser.add_argument('--dp_clip_min', type=float, default=1.0, help='minimum DP-SGD clipping norm')
-    parser.add_argument('--dp_clip_max', type=float, default=2.0, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--dp_k_min', type=float, default=0.2, help='minimum clip multiplier relative to norm EMA')
+    parser.add_argument('--dp_init_scale', type=float, default=0.6, help='initial clip scaling')
+    parser.add_argument('--dp_clip_max', type=float, default=0.8, help='maximum DP-SGD clipping norm')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--dp_noise', type=float, default=None, help='DP-SGD noise multiplier')
     group.add_argument('--dp_noise_scale', type=float, default=None, help='scale for DP noise as sigma = scale * clip')
@@ -235,7 +239,7 @@ def get_args():
     elif args.dp_noise is None:
         args.dp_noise = 0.0
     args.use_dp = int(args.dp_mode != 'off')
-    args.dp_clip = min(max(args.dp_clip, args.dp_clip_min), args.dp_clip_max)
+    args.dp_clip = min(max(args.dp_clip, 1e-4), args.dp_clip_max)
     args.log_dp_clip = math.log(max(1.0, args.dp_clip))
     return args
 
@@ -895,12 +899,13 @@ def aggregate_deltas(
     Returns
     -------
     tuple
-        mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales
+        mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
     """
     clipped = []
     scales = []
     norms = []
     layer_scales: dict[str, list[float]] = {}
+    layer_norms: dict[str, list[float]] = {}
     for delta in deltas.values():
         client = {}
         for name, tensor in delta.items():
@@ -923,12 +928,14 @@ def aggregate_deltas(
             scales.append(scale)
             norms.append(norm)
             layer_scales.setdefault(name, []).append(scale)
+            layer_norms.setdefault(name, []).append(norm)
         clipped.append(client)
     num_clients = len(clipped) or 1
     mean_norm = float(np.mean(norms)) if norms else 0.0
     median_norm = float(np.median(norms)) if norms else 0.0
     mean_scale = float(np.mean(scales)) if scales else 1.0
     layer_mean_scales = {k: float(np.mean(v)) for k, v in layer_scales.items()}
+    layer_mean_norms = {k: float(np.mean(v)) for k, v in layer_norms.items()}
 
     def _strip_prefix(n: str) -> str:
         parts = n.split('.')
@@ -1022,7 +1029,7 @@ def aggregate_deltas(
     )
     for key, tensor in step.items():
         global_w[key] += tensor
-    return mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales
+    return mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
 
 
 if __name__ == '__main__':
@@ -1266,43 +1273,31 @@ if __name__ == '__main__':
                 )
             eta_eff = args.server_lr
             if args.dp_mode == 'server':
-                mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales = aggregate_deltas(
+                mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms = aggregate_deltas(
                     global_w, deltas, args, layer_clips, noise_multipliers
                 )
                 decay = 0.9
+                for name, norm in layer_mean_norms.items():
+                    norm_ema[name] = decay * norm_ema.get(name, norm) + (1 - decay) * norm
+                    clip_min[name] = max(1e-4, args.dp_k_min * norm_ema[name])
                 for name, s in layer_mean_scales.items():
                     scale_ema[name] = decay * scale_ema.get(name, s) + (1 - decay) * s
                 if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
-                    args.dp_clip = min(max(args.dp_target_mean_scale * median_norm, args.dp_clip_min), args.dp_clip_max)
-                    args.log_dp_clip = math.log(args.dp_clip)
-                    for k in layer_clips:
-                        layer_clips[k] = args.dp_clip
+                    for name in norm_ema:
+                        layer_clips[name] = float(
+                            np.clip(args.dp_init_scale * norm_ema[name], clip_min[name], args.dp_clip_max)
+                        )
+                        log_clip[name] = math.log(layer_clips[name])
                     args.bootstrap_done = True
-                target = args.dp_target_mean_scale
                 if (round + 1) % args.dp_adapt_period == 0:
-                    updated = []
-                    for name, s_inst in layer_mean_scales.items():
-                        s_ema = scale_ema.get(name, s_inst)
-                        if abs(s_inst - target) < args.dp_deadband:
-                            continue
-                        e_ema = s_ema - target
-                        e_inst = s_inst - target
-                        e = e_inst if np.sign(e_ema) != np.sign(e_inst) else e_ema
-                        delta = -args.dp_adapt_gain * e
-                        delta = float(np.clip(delta, -math.log(1.2), math.log(1.2)))
-                        old_clip = layer_clips[name]
-                        log_clip = math.log(old_clip)
-                        log_clip = min(max(log_clip + delta, math.log(args.dp_clip_min)), math.log(args.dp_clip_max))
-                        new_clip = math.exp(log_clip)
-                        if new_clip != old_clip:
-                            layer_clips[name] = new_clip
-                            updated.append((name, old_clip, new_clip, s_inst, s_ema))
-                    if updated:
-                        logging.info('Layer-wise mean-scale control:')
-                        for name, old_clip, new_clip, s_inst, s_ema in updated:
-                            logging.info('%s — s*: %.3f, s̄: %.3f (EMA %.3f), clip: %.2f → %.2f',
-                                         name, target, s_inst, s_ema, old_clip, new_clip)
-                        logging.info('Current layer clips: %s', layer_clips)
+                    for name in layer_mean_scales:
+                        log_clip[name] = log_clip.get(name, math.log(layer_clips.get(name, args.dp_clip)))
+                        log_clip[name] += args.dp_adapt_gain * (args.dp_target_mean_scale - scale_ema[name])
+                        log_clip[name] = min(max(log_clip[name], math.log(clip_min[name])), math.log(args.dp_clip_max))
+                        layer_clips[name] = math.exp(log_clip[name])
+                logging.info('clip_min: %s', clip_min)
+                logging.info('layer_clips: %s', layer_clips)
+                logging.info('layer_mean_scales: %s', layer_mean_scales)
             else:
                 total_data_points = sum(len(net_dataidx_map[r]) for r in participating_ids)
                 fed_avg_freqs = [len(net_dataidx_map[r]) / total_data_points for r in participating_ids]


### PR DESCRIPTION
## Summary
- replace global `dp_clip_min` with per-layer `dp_k_min` floors and `dp_init_scale`
- track EMA of layer norms and adapt clips with logarithmic updates
- document new DP options and lower `dp_clip_max` default

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68beb7e4f9c4832ab48fefc4fa7ffcd1