### PR TITLE
Cap server step on pre-noise norm and add regression test

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -933,6 +933,8 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
 def aggregate_deltas(global_w, deltas, client_norms, client_scales, args, layer_clips, noise_multipliers=None, reset_bn=False):
     """Aggregate client deltas with per-parameter clipping and noise.
 
+    The server step is capped using the norm of the pre-noise averaged update.
+
     Returns
     -------
     tuple
@@ -1060,13 +1062,15 @@ def aggregate_deltas(global_w, deltas, client_norms, client_scales, args, layer_
         for update in u.values():
             u_norm_sq += update.pow(2).sum().item()
     u_norm = u_norm_sq ** 0.5
-    logging.info('||avg||=%.4f ||noise||=%.4f ||u||=%.4f', avg_norm, noise_norm, u_norm)
+    avg_norm_pre_noise = avg_norm
+    logging.info('||avg_pre_noise||=%.4f ||noise||=%.4f ||u||=%.4f', avg_norm_pre_noise, noise_norm, u_norm)
 
     desired_ratio = getattr(args, 'step_avg_target', 0.0)
-    eta_cap = args.target_step / max(u_norm, 1e-12)
+    # Cap step size using the pre-noise averaged update norm
+    eta_cap = args.target_step / max(avg_norm_pre_noise, 1e-12)
     eta_eff = min(args.server_lr, eta_cap)
     if desired_ratio > 0:
-        eta_ratio = desired_ratio * avg_norm / max(u_norm, 1e-12)
+        eta_ratio = desired_ratio * avg_norm_pre_noise / max(u_norm, 1e-12)
         eta_eff = min(args.server_lr, max(eta_eff, eta_ratio))
 
     step: dict[str, torch.Tensor] = {}
@@ -1082,9 +1086,9 @@ def aggregate_deltas(global_w, deltas, client_norms, client_scales, args, layer_
     else:
         step_norm = uncapped_step_norm
 
-    step_avg_ratio = step_norm / max(avg_norm, 1e-12)
+    step_avg_ratio = step_norm / max(avg_norm_pre_noise, 1e-12)
     logging.info(
-        'server_lr(base)=%.4g eta_eff=%.4g (cap=%s) ||step||=%.4f (uncapped %.4f) ratio(step/avg)=%.3f ||u||=%.4f',
+        'server_lr(base)=%.4g eta_eff=%.4g (cap=%s) ||step||=%.4f (uncapped %.4f) ratio(step/avg_pre_noise)=%.3f ||u||=%.4f',
         args.server_lr,
         eta_eff,
         'ON' if eta_eff < args.server_lr else 'off',

--- a/main_text.py
+++ b/main_text.py
@@ -910,6 +910,8 @@ def aggregate_deltas(
 ):
     """Aggregate client deltas with per-parameter clipping and noise.
 
+    The server step is capped using the norm of the pre-noise averaged update.
+
     Returns
     -------
     tuple
@@ -1035,9 +1037,11 @@ def aggregate_deltas(
         for update in u.values():
             u_norm_sq += update.pow(2).sum().item()
     u_norm = u_norm_sq ** 0.5
-    logging.info('||avg||=%.4f ||noise||=%.4f ||u||=%.4f', avg_norm, noise_norm, u_norm)
+    avg_norm_pre_noise = avg_norm
+    logging.info('||avg_pre_noise||=%.4f ||noise||=%.4f ||u||=%.4f', avg_norm_pre_noise, noise_norm, u_norm)
 
-    eta_cap = args.target_step / max(u_norm, 1e-12)
+    # Cap step size using the pre-noise averaged update norm
+    eta_cap = args.target_step / max(avg_norm_pre_noise, 1e-12)
     eta_eff = min(args.server_lr, eta_cap)
 
     step: dict[str, torch.Tensor] = {}
@@ -1054,13 +1058,13 @@ def aggregate_deltas(
         step_norm = uncapped_step_norm
 
     logging.info(
-        'server_lr(base)=%.4g eta_eff=%.4g (cap=%s) ||step||=%.4f (uncapped %.4f) ratio(step/avg)=%.3f ||u||=%.4f',
+        'server_lr(base)=%.4g eta_eff=%.4g (cap=%s) ||step||=%.4f (uncapped %.4f) ratio(step/avg_pre_noise)=%.3f ||u||=%.4f',
         args.server_lr,
         eta_eff,
         'ON' if eta_eff < args.server_lr else 'off',
         step_norm,
         uncapped_step_norm,
-        step_norm / max(avg_norm, 1e-12),
+        step_norm / max(avg_norm_pre_noise, 1e-12),
         u_norm,
     )
     for key, tensor in step.items():

--- a/tests/test_step_cap_noise.py
+++ b/tests/test_step_cap_noise.py
@@ -1,0 +1,57 @@
+import argparse
+import os
+import sys
+import types
+import torch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+opacus_stub = types.SimpleNamespace(PrivacyEngine=None, grad_sample=types.SimpleNamespace(GradSampleModule=None))
+sys.modules.setdefault('opacus', opacus_stub)
+sys.modules.setdefault('opacus.grad_sample', opacus_stub.grad_sample)
+model_stub = types.SimpleNamespace(WordEmbed=object)
+sys.modules.setdefault('model', model_stub)
+utils_stub = types.SimpleNamespace()
+sys.modules.setdefault('utils', utils_stub)
+import main_image
+
+def test_eta_cap_uses_pre_noise_norm():
+    torch.manual_seed(0)
+    global_w = {'w': torch.zeros(1)}
+    deltas = {
+        0: {'w': torch.tensor([1.0])},
+        1: {'w': torch.tensor([1.0])},
+    }
+    client_norms = {}
+    client_scales = {0: 1.0, 1: 1.0}
+    args = argparse.Namespace(
+        dp_clip=1.0,
+        dp_noise=0.0,
+        dp_constant_noise=False,
+        server_momentum=0.0,
+        server_lr=1.0,
+        target_step=1.0,
+    )
+    layer_clips = {'w': 1.0}
+    noise_multipliers = {'w': 1e6}
+
+    num_clients = len(deltas)
+    avg_update = torch.stack([d['w'] for d in deltas.values()]).mean(0)
+    avg_norm_pre_noise = torch.norm(avg_update).item()
+    noise_std = noise_multipliers['w'] * layer_clips['w'] / num_clients
+    noise = torch.randn_like(avg_update) * noise_std
+    u = avg_update + noise
+    u_norm = torch.norm(u).item()
+    assert avg_norm_pre_noise < 10
+    assert u_norm > 1e3
+
+    torch.manual_seed(0)
+    _, _, _, eta_eff, _, _ = main_image.aggregate_deltas(
+        global_w,
+        deltas,
+        client_norms,
+        client_scales,
+        args,
+        layer_clips,
+        noise_multipliers,
+    )
+    assert abs(eta_eff - args.server_lr) < 1e-6


### PR DESCRIPTION
## Summary
- Cap server step size using the pre-noise aggregated update norm in both image and text aggregators
- Clarify logging and docstrings to reference `avg_pre_noise`
- Add regression test ensuring heavy noise doesn't shrink the effective step

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_step_cap_noise.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf093f3cc0832ab6f6bb0eb235e647