### PR TITLE
Enable DP bootstrap pre-clip phase

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -930,14 +930,31 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
     return nets, epsilon, avg_loss
 
 
-def aggregate_deltas(global_w, deltas, client_norms, client_scales, args, layer_clips, noise_multipliers=None, reset_bn=False):
-    """Aggregate client deltas with per-parameter clipping and noise.
+def aggregate_deltas(
+    global_w,
+    deltas,
+    client_norms,
+    client_scales,
+    args,
+    layer_clips,
+    noise_multipliers=None,
+    reset_bn=False,
+    pre_clip_only=False,
+):
+    """Aggregate client deltas with per-parameter clipping.
+
+    When ``pre_clip_only`` is ``True``, the function returns the clipped mean
+    update and norm statistics **without** adding noise or applying the update
+    to ``global_w``. This enables a bootstrap phase to set per-layer clipping
+    thresholds. When ``pre_clip_only`` is ``False``, noise is added and the
+    update is applied to ``global_w`` as before.
 
     Returns
     -------
     tuple
-        mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
+        avg_updates, mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
     """
+
     def _is_bn_or_bias(name: str, tensor: torch.Tensor) -> bool:
         return '.bn' in name or name.endswith('.bias') or tensor.dim() == 1
 
@@ -1008,6 +1025,8 @@ def aggregate_deltas(global_w, deltas, client_norms, client_scales, args, layer_
         float(np.max(scales)) if scales else 1.0,
     )
     logging.info('Block median scales: %s', ' '.join(f'{k}:{v:.3f}' for k, v in block_medians.items()))
+
+    avg_updates: dict[str, torch.Tensor] = {}
     avg_norm_sq = 0.0
     noise_norm_sq = 0.0
     updates = {}
@@ -1019,17 +1038,21 @@ def aggregate_deltas(global_w, deltas, client_norms, client_scales, args, layer_
                 continue
             stacked = torch.stack([d[key].float() for d in deltas.values()])
             avg = stacked.mean(0)
-            global_w[key] += avg if global_w[key].is_floating_point() else avg.long()
-            if reset_bn:
-                if 'running_var' in key:
-                    global_w[key].fill_(1.0)
-                else:
-                    global_w[key].zero_()
+            avg_updates[key] = avg
+            if not pre_clip_only:
+                global_w[key] += avg if global_w[key].is_floating_point() else avg.long()
+                if reset_bn:
+                    if 'running_var' in key:
+                        global_w[key].fill_(1.0)
+                    else:
+                        global_w[key].zero_()
             continue
         stacked = torch.stack([d[key] for d in clipped])
         avg_update = stacked.mean(dim=0)
-        if _is_bn_or_bias(key, global_w[key]):
-            updates[key] = avg_update
+        avg_updates[key] = avg_update
+        if pre_clip_only or _is_bn_or_bias(key, global_w[key]):
+            if not pre_clip_only and _is_bn_or_bias(key, global_w[key]):
+                updates[key] = avg_update
             continue
         noise_mult = args.dp_noise
         if noise_multipliers is not None:
@@ -1043,6 +1066,10 @@ def aggregate_deltas(global_w, deltas, client_norms, client_scales, args, layer_
         updates[key] = update
         avg_norm_sq += avg_update.pow(2).sum().item()
         noise_norm_sq += noise.pow(2).sum().item()
+
+    if pre_clip_only:
+        return avg_updates, mean_norm, median_norm, mean_scale, 0.0, layer_mean_scales, layer_mean_norms
+
     avg_norm = avg_norm_sq ** 0.5
     noise_norm = noise_norm_sq ** 0.5
 
@@ -1100,7 +1127,7 @@ def aggregate_deltas(global_w, deltas, client_norms, client_scales, args, layer_
     for key, tensor in step.items():
         global_w[key] += tensor
 
-    return mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
+    return avg_updates, mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
 
 
 if __name__ == '__main__':
@@ -1344,7 +1371,34 @@ if __name__ == '__main__':
                 )
             eta_eff = args.server_lr
             if args.dp_mode == 'server':
-                mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms = aggregate_deltas(
+                if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
+                    _, _, _, _, _, layer_mean_scales, layer_mean_norms = aggregate_deltas(
+                        global_w,
+                        deltas,
+                        client_norms,
+                        client_scales,
+                        args,
+                        layer_clips,
+                        noise_multipliers,
+                        pre_clip_only=True,
+                    )
+                    logging.info('Bootstrapping layer clips from first-round statistics')
+                    for name, norm in layer_mean_norms.items():
+                        if '.bn' in name or name.endswith('.bias'):
+                            continue
+                        norm_ema[name] = norm
+                        clip_min[name] = max(1e-4, args.dp_k_min * norm_ema[name])
+                    for name, s in layer_mean_scales.items():
+                        if '.bn' in name or name.endswith('.bias'):
+                            continue
+                        scale_ema[name] = s
+                    for name in norm_ema:
+                        layer_clips[name] = float(
+                            np.clip(args.dp_init_scale * norm_ema[name], clip_min[name], args.dp_clip_max)
+                        )
+                        log_clip[name] = math.log(layer_clips[name])
+                    args.bootstrap_done = True
+                _, mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms = aggregate_deltas(
                     global_w, deltas, client_norms, client_scales, args, layer_clips, noise_multipliers
                 )
                 logging.info('Aggregate mean scale (incl client): %.4f', mean_scale)
@@ -1359,11 +1413,6 @@ if __name__ == '__main__':
                     if '.bn' in name or name.endswith('.bias'):
                         continue
                     scale_ema[name] = decay * scale_ema.get(name, s) + (1 - decay) * s
-                if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
-                    for name in norm_ema:
-                        layer_clips[name] = float(np.clip(args.dp_init_scale * norm_ema[name], clip_min[name], args.dp_clip_max))
-                        log_clip[name] = math.log(layer_clips[name])
-                    args.bootstrap_done = True
                 if (round + 1) % args.dp_adapt_period == 0:
                     for name in layer_mean_scales:
                         if '.bn' in name or name.endswith('.bias'):

--- a/main_text.py
+++ b/main_text.py
@@ -907,14 +907,21 @@ def aggregate_deltas(
     layer_clips,
     noise_multipliers: dict[str, float] | None = None,
     reset_bn: bool = False,
+    pre_clip_only: bool = False,
 ):
-    """Aggregate client deltas with per-parameter clipping and noise.
+    """Aggregate client deltas with per-parameter clipping.
+
+    When ``pre_clip_only`` is ``True``, return the clipped mean update and norm
+    statistics without adding noise or applying the update to ``global_w``. This
+    enables a bootstrap phase to determine clipping thresholds. When ``pre_clip_only``
+    is ``False``, noise is added and the update is applied to ``global_w``.
 
     Returns
     -------
     tuple
-        mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
+        avg_updates, mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
     """
+
     def _is_bn_or_bias(name: str, tensor: torch.Tensor) -> bool:
         return '.bn' in name or name.endswith('.bias') or tensor.dim() == 1
 
@@ -988,6 +995,8 @@ def aggregate_deltas(
         float(np.max(scales)) if scales else 1.0,
     )
     logging.info('Block median scales: %s', ' '.join(f'{k}:{v:.3f}' for k, v in block_medians.items()))
+
+    avg_updates: dict[str, torch.Tensor] = {}
     avg_norm_sq = 0.0
     noise_norm_sq = 0.0
     updates = {}
@@ -995,17 +1004,23 @@ def aggregate_deltas(
         if 'few_classify' in key or 'transform_layer' in key or 'transformer' in key:
             continue
         if any(s in key for s in ('running_mean', 'running_var', 'num_batches_tracked')):
-            global_w[key] += torch.stack([d[key] for d in deltas.values()]).mean(0)
-            if reset_bn:
-                if 'running_var' in key:
-                    global_w[key].fill_(1.0)
-                else:
-                    global_w[key].zero_()
+            stacked = torch.stack([d[key] for d in deltas.values()])
+            avg = stacked.mean(0)
+            avg_updates[key] = avg
+            if not pre_clip_only:
+                global_w[key] += avg
+                if reset_bn:
+                    if 'running_var' in key:
+                        global_w[key].fill_(1.0)
+                    else:
+                        global_w[key].zero_()
             continue
         stacked = torch.stack([d[key] for d in clipped])
         avg_update = stacked.mean(dim=0)
-        if _is_bn_or_bias(key, global_w[key]):
-            updates[key] = avg_update
+        avg_updates[key] = avg_update
+        if pre_clip_only or _is_bn_or_bias(key, global_w[key]):
+            if not pre_clip_only and _is_bn_or_bias(key, global_w[key]):
+                updates[key] = avg_update
             continue
         noise_mult = args.dp_noise
         if noise_multipliers is not None:
@@ -1019,6 +1034,10 @@ def aggregate_deltas(
         updates[key] = update
         avg_norm_sq += avg_update.pow(2).sum().item()
         noise_norm_sq += noise.pow(2).sum().item()
+
+    if pre_clip_only:
+        return avg_updates, mean_norm, median_norm, mean_scale, 0.0, layer_mean_scales, layer_mean_norms
+
     avg_norm = avg_norm_sq ** 0.5
     noise_norm = noise_norm_sq ** 0.5
 
@@ -1065,7 +1084,7 @@ def aggregate_deltas(
     )
     for key, tensor in step.items():
         global_w[key] += tensor
-    return mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
+    return avg_updates, mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms
 
 
 if __name__ == '__main__':
@@ -1309,7 +1328,34 @@ if __name__ == '__main__':
                 )
             eta_eff = args.server_lr
             if args.dp_mode == 'server':
-                mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms = aggregate_deltas(
+                if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
+                    _, _, _, _, _, layer_mean_scales, layer_mean_norms = aggregate_deltas(
+                        global_w,
+                        deltas,
+                        client_norms,
+                        client_scales,
+                        args,
+                        layer_clips,
+                        noise_multipliers,
+                        pre_clip_only=True,
+                    )
+                    logging.info('Bootstrapping layer clips from first-round statistics')
+                    for name, norm in layer_mean_norms.items():
+                        if '.bn' in name or name.endswith('.bias'):
+                            continue
+                        norm_ema[name] = norm
+                        clip_min[name] = max(1e-4, args.dp_k_min * norm_ema[name])
+                    for name, s in layer_mean_scales.items():
+                        if '.bn' in name or name.endswith('.bias'):
+                            continue
+                        scale_ema[name] = s
+                    for name in norm_ema:
+                        layer_clips[name] = float(
+                            np.clip(args.dp_init_scale * norm_ema[name], clip_min[name], args.dp_clip_max)
+                        )
+                        log_clip[name] = math.log(layer_clips[name])
+                    args.bootstrap_done = True
+                _, mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms = aggregate_deltas(
                     global_w, deltas, client_norms, client_scales, args, layer_clips, noise_multipliers
                 )
                 logging.info('Aggregate mean scale (incl client): %.4f', mean_scale)
@@ -1324,13 +1370,6 @@ if __name__ == '__main__':
                     if '.bn' in name or name.endswith('.bias'):
                         continue
                     scale_ema[name] = decay * scale_ema.get(name, s) + (1 - decay) * s
-                if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
-                    for name in norm_ema:
-                        layer_clips[name] = float(
-                            np.clip(args.dp_init_scale * norm_ema[name], clip_min[name], args.dp_clip_max)
-                        )
-                        log_clip[name] = math.log(layer_clips[name])
-                    args.bootstrap_done = True
                 if (round + 1) % args.dp_adapt_period == 0:
                     for name in layer_mean_scales:
                         if '.bn' in name or name.endswith('.bias'):


### PR DESCRIPTION
## Summary
- add `pre_clip_only` flag to `aggregate_deltas` for collecting norms without noise
- bootstrap per-layer clipping using a pre-clip pass before first noisy aggregation
- document and log the two-phase DP bootstrap process

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bf0a404790832a9a9a3edef21388a7