### PR TITLE
Expose L2 regularization for logistic regression classifiers

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -151,6 +151,10 @@ def get_args():
     parser.add_argument('--comm_round', type=int, default=5000, help='number of maximum communication roun')
     parser.add_argument('--optimizer', type=str, default='sgd',
                         help='optimizer: sgd, adam, amsgrad, or adamw')
+    parser.add_argument('--logreg_l2', type=float, default=1e-4,
+                        help='L2 regularization for logistic regression')
+    parser.add_argument('--logreg_iter_factor', type=int, default=100,
+                        help='multiplier for logistic regression max_iter')
     
     
     parser.add_argument("--bert_cache_dir", default=None, type=str,
@@ -743,7 +747,12 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
                     clf = LogisticRegression(support_features.size(1), N).to(support_features.device).float()
                     with torch.autocast('cuda', enabled=False):
-                        clf.fit(support_features, support_labels, max_iter=1000)
+                        clf.fit(
+                            support_features,
+                            support_labels,
+                            max_iter=args.logreg_iter_factor * K,
+                            l2_reg=args.logreg_l2,
+                        )
                         with torch.inference_mode():
                             out = clf.predict_proba(query_features)
 

--- a/main_text.py
+++ b/main_text.py
@@ -143,6 +143,10 @@ def get_args():
     parser.add_argument('--comm_round', type=int, default=5000, help='number of maximum communication roun')
     parser.add_argument('--optimizer', type=str, default='adam',
                         help='optimizer: sgd, adam, amsgrad, or adamw')
+    parser.add_argument('--logreg_l2', type=float, default=1e-4,
+                        help='L2 regularization for logistic regression')
+    parser.add_argument('--logreg_iter_factor', type=int, default=100,
+                        help='multiplier for logistic regression max_iter')
     
     
     parser.add_argument("--bert_cache_dir", default=None, type=str,
@@ -713,7 +717,12 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
 
                     clf = LogisticRegression(support_features.size(1), N).to(support_features.device).float()
                     with torch.autocast('cuda', enabled=False):
-                        clf.fit(support_features, support_labels, max_iter=1000)
+                        clf.fit(
+                            support_features,
+                            support_labels,
+                            max_iter=args.logreg_iter_factor * K,
+                            l2_reg=args.logreg_l2,
+                        )
                         with torch.inference_mode():
                             out = clf.predict_proba(query_features)
 

--- a/model.py
+++ b/model.py
@@ -46,9 +46,7 @@ class LogisticRegression(nn.Module):
             out = self.forward(X)
             loss = criterion(out, y)
             if l2_reg > 0:
-                l2_penalty = 0
-                for p in self.parameters():
-                    l2_penalty += p.pow(2).sum()
+                l2_penalty = sum(p.pow(2).sum() for p in self.parameters())
                 loss = loss + l2_reg * l2_penalty
             loss.backward()
             return loss


### PR DESCRIPTION
## Summary
- allow specifying L2 regularization strength and iteration multiplier for logistic regression fits
- propagate new options through `main_image.py` and `main_text.py`
- compute max_iter as `K` multiplied by a configurable factor

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68bfbdee7864832a8d26220fb3fc4c19