### PR TITLE
Adjust inner_lr scaling

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -592,7 +592,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             if mode == 'train':
                 loss_all = 0
                 if args.fine_tune_steps > 0:
-                    inner_lr = args.fine_tune_lr * K / REFERENCE_SHOT
+                    inner_lr = args.fine_tune_lr * min(1.0, (K / REFERENCE_SHOT) ** 0.5)
                     fine_tune_steps = min(args.fine_tune_steps, K)
                     gmodel_base = gmodel._module if hasattr(gmodel, '_module') else gmodel
                     net_new = copy.deepcopy(model_template)

--- a/main_text.py
+++ b/main_text.py
@@ -570,7 +570,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     args.meta_lr=0.001
                     #args.fine_tune_steps=0
                 if args.fine_tune_steps>0:
-                    inner_lr = args.fine_tune_lr * K / REFERENCE_SHOT
+                    inner_lr = args.fine_tune_lr * min(1.0, (K / REFERENCE_SHOT) ** 0.5)
                     fine_tune_steps = min(args.fine_tune_steps, K)
                     gmodel_base = gmodel._module if hasattr(gmodel, '_module') else gmodel
                     net_new = copy.deepcopy(model_template)


### PR DESCRIPTION
## Summary
- adjust inner learning rate scaling in main_text.py and main_image.py to use a square-root ratio capped at one

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfc71eacbc832a835445c130ac2f4e