### PR TITLE
Adjust fine-tuning step calculation

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -36,6 +36,11 @@ noise_multipliers: dict[str, float] = {}
 
 REFERENCE_SHOT = 5
 
+
+def clamp(value: int, min_value: int, max_value: int) -> int:
+    """Clamp value within the inclusive range [min_value, max_value]."""
+    return max(min_value, min(value, max_value))
+
 from collections import defaultdict
 
 fine_split=defaultdict(list)
@@ -592,8 +597,12 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
             if mode == 'train':
                 loss_all = 0
                 if args.fine_tune_steps > 0:
+                    base_steps = args.fine_tune_steps
                     inner_lr = args.fine_tune_lr * min(1.0, (K / REFERENCE_SHOT) ** 0.5)
-                    fine_tune_steps = min(args.fine_tune_steps, K)
+                    upper_bound = base_steps if base_steps < 10 else 10
+                    fine_tune_steps = clamp(
+                        round(base_steps * (K / REFERENCE_SHOT) ** 0.5), 2, upper_bound
+                    )
                     gmodel_base = gmodel._module if hasattr(gmodel, '_module') else gmodel
                     net_new = copy.deepcopy(model_template)
                     net_new.load_state_dict(gmodel_base.state_dict())

--- a/main_text.py
+++ b/main_text.py
@@ -36,6 +36,11 @@ noise_multipliers: dict[str, float] = {}
 
 REFERENCE_SHOT = 5
 
+
+def clamp(value: int, min_value: int, max_value: int) -> int:
+    """Clamp value within the inclusive range [min_value, max_value]."""
+    return max(min_value, min(value, max_value))
+
 from collections import defaultdict
 
 fine_split=defaultdict(list)
@@ -570,8 +575,12 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     args.meta_lr=0.001
                     #args.fine_tune_steps=0
                 if args.fine_tune_steps>0:
+                    base_steps = args.fine_tune_steps
                     inner_lr = args.fine_tune_lr * min(1.0, (K / REFERENCE_SHOT) ** 0.5)
-                    fine_tune_steps = min(args.fine_tune_steps, K)
+                    upper_bound = base_steps if base_steps < 10 else 10
+                    fine_tune_steps = clamp(
+                        round(base_steps * (K / REFERENCE_SHOT) ** 0.5), 2, upper_bound
+                    )
                     gmodel_base = gmodel._module if hasattr(gmodel, '_module') else gmodel
                     net_new = copy.deepcopy(model_template)
                     net_new.load_state_dict(gmodel_base.state_dict())


### PR DESCRIPTION
## Summary
- add clamp helper to bound dynamic fine-tuning steps
- scale fine-tuning steps with task shot count and REFERENCE_SHOT

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfc8ef72a4832a9cf1156a5e916a48