### PR TITLE
Call eval on cloned models before inner-loop updates

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -607,6 +607,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     gmodel_base = gmodel._module if hasattr(gmodel, '_module') else gmodel
                     net_new = copy.deepcopy(model_template)
                     net_new.load_state_dict(gmodel_base.state_dict())
+                    net_new.eval()
 
                     for j in range(fine_tune_steps):
                         net_new.zero_grad()

--- a/main_text.py
+++ b/main_text.py
@@ -585,6 +585,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                     gmodel_base = gmodel._module if hasattr(gmodel, '_module') else gmodel
                     net_new = copy.deepcopy(model_template)
                     net_new.load_state_dict(gmodel_base.state_dict())
+                    net_new.eval()
 
                     for j in range(fine_tune_steps):
                         net_new.zero_grad()


### PR DESCRIPTION
## Summary
- Ensure cloned models switch to evaluation mode before meta-training inner loops

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfcc1260e8832a917ea4edb5b170e9