### PR TITLE
Refactor DP accounting and logging

### DIFF
--- a/dp_utils.py
+++ b/dp_utils.py
@@ -1,6 +1,87 @@
 import math
 from opacus.grad_sample import GradSampleModule
 
+DP_EVENTS: list[tuple[float, float]] = []
+_OPACUS_ACCOUNTANT = None
+
+
+def record_dp_event(q, sigma, accountant=None):
+    """Record a noisy aggregation for privacy accounting.
+
+    Parameters
+    ----------
+    q : float
+        Sampling probability for this aggregation.
+    sigma : float
+        Noise multiplier applied during this aggregation.
+    accountant : str, optional
+        When set to ``'opacus'`` an Opacus accountant tracks the event.
+        Otherwise the event is stored for composition by :func:`get_epsilon`.
+    """
+    global _OPACUS_ACCOUNTANT
+    if accountant == 'opacus':
+        from opacus.accountants import RDPAccountant
+
+        if _OPACUS_ACCOUNTANT is None:
+            _OPACUS_ACCOUNTANT = RDPAccountant()
+        _OPACUS_ACCOUNTANT.step(noise_multiplier=sigma, sample_rate=q)
+    else:
+        DP_EVENTS.append((q, sigma))
+
+
+def get_epsilon(delta, accountant=None):
+    """Return composed privacy loss ε from recorded events.
+
+    Parameters
+    ----------
+    delta : float
+        Target δ parameter of differential privacy.
+    accountant : str, optional
+        Accounting method. ``'rdp'`` or ``'prv'`` compose events manually, while
+        ``'opacus'`` delegates to an Opacus accountant.
+
+    Returns
+    -------
+    float
+        Composed privacy loss ε.
+    """
+    if accountant == 'opacus':
+        if _OPACUS_ACCOUNTANT is None:
+            return 0.0
+        return _OPACUS_ACCOUNTANT.get_epsilon(delta)
+    return _compose_events(DP_EVENTS, delta, accountant)
+
+
+def _compose_events(events, delta, accountant):
+    if not events:
+        return 0.0
+    if accountant == 'rdp':
+        orders = [1 + x / 10.0 for x in range(1, 100)] + list(range(12, 64))
+        rdp = [0.0 for _ in orders]
+        for q, sigma in events:
+            for i, order in enumerate(orders):
+                rdp[i] += (q ** 2) * order / (2 * sigma ** 2)
+        return min(r - math.log(delta) / (o - 1) for r, o in zip(rdp, orders))
+    if accountant == 'prv':
+        try:
+            from prv_accountant import Accountant
+        except Exception as e:  # pragma: no cover - optional dependency
+            raise ImportError('prv_accountant is required for accountant="prv"') from e
+
+        acc = Accountant(
+            noise_multiplier=events[0][1],
+            sampling_probability=events[0][0],
+            delta=delta,
+            max_compositions=len(events),
+            eps_error=0.1,
+        )
+        for q, sigma in events[1:]:
+            acc.compose(noise_multiplier=sigma, sampling_probability=q)
+        eps = acc.compute_epsilon(len(events))
+        return eps if isinstance(eps, float) else eps[1]
+    sigma_min = min(s for _, s in events)
+    return math.sqrt(2 * len(events) * math.log(1 / delta)) / sigma_min
+
 
 def remove_dp_hooks(model):
     """Remove differential privacy hooks and cached gradients.

--- a/main_image.py
+++ b/main_image.py
@@ -1112,6 +1112,24 @@ def aggregate_deltas(
     if pre_clip_only:
         return avg_updates, mean_norm, median_norm, mean_scale, 0.0, layer_mean_scales, layer_mean_norms
 
+    if getattr(args, 'dp_mode', 'off') != 'off':
+        num_participants = len(deltas)
+        if num_participants > 0:
+            total_clients = getattr(args, 'total_clients', getattr(args, 'n_parties', num_participants))
+            q = num_participants / total_clients
+            if args.dp_constant_noise and noise_multipliers:
+                sigma_eff = min(noise_multipliers.values())
+            else:
+                sigma_eff = args.dp_noise
+            dp_utils.record_dp_event(q, sigma_eff, accountant=args.dp_accountant)
+            logging.info(
+                '[acct] round=%s, q=%d/%d, sigma_eff=%.4f, noise_added=True',
+                getattr(args, 'current_round', '?'),
+                num_participants,
+                total_clients,
+                sigma_eff,
+            )
+
     avg_norm = avg_norm_sq ** 0.5
     noise_norm = noise_norm_sq ** 0.5
 
@@ -1335,7 +1353,6 @@ if __name__ == '__main__':
         best_confident_acc = 0
         no_improve = 0
 
-        dp_steps = 0
         for comm_round in range(n_comm_rounds):
             #logger.info('in comm round:' + str(comm_round))
             party_list_this_round = party_list_rounds[comm_round]
@@ -1397,24 +1414,23 @@ if __name__ == '__main__':
 
             logger.info('Round %d loss %.4f', comm_round, round_loss)
             print(f'Round {comm_round} loss: {round_loss:.4f}')
-            if args.dp_mode == 'local':
-                dp_steps += args.num_train_tasks * len(participating_ids)
-            elif args.dp_mode == 'server':
-                dp_steps += 1
-            if args.dp_mode != 'off':
-                if args.dp_constant_noise and noise_multipliers:
-                    noise_for_eps = min(noise_multipliers.values())
-                else:
-                    noise_for_eps = args.dp_noise
-                epsilon = dp_utils.compute_epsilon(
-                    dp_steps,
-                    noise_for_eps,
-                    args.dp_delta,
-                    accountant=args.dp_accountant,
-                    sampling_rate=len(participating_ids) / args.n_parties,
+
+            num_participants = len(participating_ids)
+            total_clients = getattr(args, 'total_clients', args.n_parties)
+            if args.dp_mode == 'local' and num_participants > 0:
+                q = num_participants / total_clients
+                for _ in range(args.num_train_tasks * num_participants):
+                    dp_utils.record_dp_event(q, args.dp_noise, accountant=args.dp_accountant)
+                logging.info(
+                    '[acct] round=%d, q=%d/%d, sigma_eff=%.4f, noise_added=True',
+                    comm_round,
+                    num_participants,
+                    total_clients,
+                    args.dp_noise,
                 )
             eta_eff = args.server_lr
             if args.dp_mode == 'server':
+                args.current_round = comm_round
                 if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
                     _, _, _, _, _, layer_mean_scales, layer_mean_norms = aggregate_deltas(
                         global_w,
@@ -1507,6 +1523,8 @@ if __name__ == '__main__':
 
             print('>> Current Round: {}'.format(comm_round))
             logger.info('>> Current Round: {}'.format(comm_round))
+            if args.dp_mode != 'off':
+                epsilon = dp_utils.get_epsilon(args.dp_delta, accountant=args.dp_accountant)
             if args.dp_mode != 'off' and args.print_eps:
                 print('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
                 logger.info('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))

--- a/main_text.py
+++ b/main_text.py
@@ -1080,6 +1080,24 @@ def aggregate_deltas(
     if pre_clip_only:
         return avg_updates, mean_norm, median_norm, mean_scale, 0.0, layer_mean_scales, layer_mean_norms
 
+    if getattr(args, 'dp_mode', 'off') != 'off':
+        num_participants = len(deltas)
+        if num_participants > 0:
+            total_clients = getattr(args, 'total_clients', getattr(args, 'n_parties', num_participants))
+            q = num_participants / total_clients
+            if args.dp_constant_noise and noise_multipliers:
+                sigma_eff = min(noise_multipliers.values())
+            else:
+                sigma_eff = args.dp_noise
+            dp_utils.record_dp_event(q, sigma_eff, accountant=args.dp_accountant)
+            logging.info(
+                '[acct] round=%s, q=%d/%d, sigma_eff=%.4f, noise_added=True',
+                getattr(args, 'current_round', '?'),
+                num_participants,
+                total_clients,
+                sigma_eff,
+            )
+
     avg_norm = avg_norm_sq ** 0.5
     noise_norm = noise_norm_sq ** 0.5
 
@@ -1292,7 +1310,6 @@ if __name__ == '__main__':
         best_acc_5 = 0
         no_improve = 0
 
-        dp_steps = 0
         for comm_round in range(n_comm_rounds):
             #logger.info('in comm round:' + str(comm_round))
             party_list_this_round = party_list_rounds[comm_round]
@@ -1354,24 +1371,23 @@ if __name__ == '__main__':
 
             logger.info('Round %d loss %.4f', comm_round, round_loss)
             print(f'Round {comm_round} loss: {round_loss:.4f}')
-            if args.dp_mode == 'local':
-                dp_steps += args.num_train_tasks * len(participating_ids)
-            elif args.dp_mode == 'server':
-                dp_steps += 1
-            if args.dp_mode != 'off':
-                if args.dp_constant_noise and noise_multipliers:
-                    noise_for_eps = min(noise_multipliers.values())
-                else:
-                    noise_for_eps = args.dp_noise
-                epsilon = dp_utils.compute_epsilon(
-                    dp_steps,
-                    noise_for_eps,
-                    args.dp_delta,
-                    accountant=args.dp_accountant,
-                    sampling_rate=len(participating_ids) / args.n_parties,
+
+            num_participants = len(participating_ids)
+            total_clients = getattr(args, 'total_clients', args.n_parties)
+            if args.dp_mode == 'local' and num_participants > 0:
+                q = num_participants / total_clients
+                for _ in range(args.num_train_tasks * num_participants):
+                    dp_utils.record_dp_event(q, args.dp_noise, accountant=args.dp_accountant)
+                logging.info(
+                    '[acct] round=%d, q=%d/%d, sigma_eff=%.4f, noise_added=True',
+                    comm_round,
+                    num_participants,
+                    total_clients,
+                    args.dp_noise,
                 )
             eta_eff = args.server_lr
             if args.dp_mode == 'server':
+                args.current_round = comm_round
                 if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
                     _, _, _, _, _, layer_mean_scales, layer_mean_norms = aggregate_deltas(
                         global_w,
@@ -1461,6 +1477,8 @@ if __name__ == '__main__':
 
             print('>> Current Round: {}'.format(comm_round))
             logger.info('>> Current Round: {}'.format(comm_round))
+            if args.dp_mode != 'off':
+                epsilon = dp_utils.get_epsilon(args.dp_delta, accountant=args.dp_accountant)
             if args.dp_mode != 'off' and args.print_eps:
                 print('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))
                 logger.info('Current epsilon {:.4f}, delta {:.1e}'.format(epsilon, args.dp_delta))


### PR DESCRIPTION
## Summary
- replace manual dp_steps tracking with event-based DP accounting
- record and log DP events after noise is added to model updates
- compute epsilon from recorded events instead of incremental counters

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_step_cap_noise.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bfdc7c6908832a82a7984c8b179ae2