### PR TITLE
Compute aggregate sigma for DP accounting

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -1118,16 +1118,24 @@ def aggregate_deltas(
             total_clients = getattr(args, 'total_clients', getattr(args, 'n_parties', num_participants))
             q = num_participants / total_clients
             if args.dp_constant_noise and noise_multipliers:
-                sigma_eff = min(noise_multipliers.values())
+                sigmas = list(noise_multipliers.values())
+                sigma_eq = (len(sigmas) / sum(1 / (s**2) for s in sigmas)) ** 0.5
+                logging.info(
+                    '[acct] sigmas min/median/max: %.4f/%.4f/%.4f, sigma_eq=%.4f',
+                    min(sigmas),
+                    float(np.median(sigmas)),
+                    max(sigmas),
+                    sigma_eq,
+                )
             else:
-                sigma_eff = args.dp_noise
-            dp_utils.record_dp_event(q, sigma_eff, accountant=args.dp_accountant)
+                sigma_eq = args.dp_noise
+            dp_utils.record_dp_event(q, sigma_eq, accountant=args.dp_accountant)
             logging.info(
-                '[acct] round=%s, q=%d/%d, sigma_eff=%.4f, noise_added=True',
+                '[acct] round=%s, q=%d/%d, sigma_eq=%.4f, noise_added=True',
                 getattr(args, 'current_round', '?'),
                 num_participants,
                 total_clients,
-                sigma_eff,
+                sigma_eq,
             )
 
     avg_norm = avg_norm_sq ** 0.5

--- a/main_text.py
+++ b/main_text.py
@@ -1086,16 +1086,24 @@ def aggregate_deltas(
             total_clients = getattr(args, 'total_clients', getattr(args, 'n_parties', num_participants))
             q = num_participants / total_clients
             if args.dp_constant_noise and noise_multipliers:
-                sigma_eff = min(noise_multipliers.values())
+                sigmas = list(noise_multipliers.values())
+                sigma_eq = (len(sigmas) / sum(1 / (s**2) for s in sigmas)) ** 0.5
+                logging.info(
+                    '[acct] sigmas min/median/max: %.4f/%.4f/%.4f, sigma_eq=%.4f',
+                    min(sigmas),
+                    float(np.median(sigmas)),
+                    max(sigmas),
+                    sigma_eq,
+                )
             else:
-                sigma_eff = args.dp_noise
-            dp_utils.record_dp_event(q, sigma_eff, accountant=args.dp_accountant)
+                sigma_eq = args.dp_noise
+            dp_utils.record_dp_event(q, sigma_eq, accountant=args.dp_accountant)
             logging.info(
-                '[acct] round=%s, q=%d/%d, sigma_eff=%.4f, noise_added=True',
+                '[acct] round=%s, q=%d/%d, sigma_eq=%.4f, noise_added=True',
                 getattr(args, 'current_round', '?'),
                 num_participants,
                 total_clients,
-                sigma_eff,
+                sigma_eq,
             )
 
     avg_norm = avg_norm_sq ** 0.5


### PR DESCRIPTION
## Summary
- Compute equivalent aggregate `sigma_eq` from layer noise multipliers
- Pass `sigma_eq` to `dp_utils.record_dp_event`
- Log `sigma_eq` alongside min/median/max sigma values for debugging

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bfe3af209c832ab1329fb5f357719a