### PR TITLE
Handle prefixed module names in DP decay

### DIFF
--- a/dp_utils.py
+++ b/dp_utils.py
@@ -8,6 +8,29 @@ except Exception:  # pragma: no cover - optional dependency
         pass
 
 
+BLOCK_PREFIXES = ('layer1', 'layer2', 'layer3', 'layer4', 'fc', 'head')
+
+
+def get_param_block(name):
+    """Return the first recognised block token from a parameter name.
+
+    Parameters
+    ----------
+    name : str
+        Dot-delimited parameter name as returned by ``state_dict``.
+
+    Returns
+    -------
+    str | None
+        First token matching a known block prefix, or ``None`` when no match is
+        found.
+    """
+    for token in name.split('.'):
+        if token in BLOCK_PREFIXES:
+            return token
+    return None
+
+
 def remove_dp_hooks(model):
     """Remove differential privacy hooks and cached gradients.
 

--- a/main_image.py
+++ b/main_image.py
@@ -22,7 +22,7 @@ from utils import *
 from opacus import PrivacyEngine
 from opacus.grad_sample import GradSampleModule
 import dp_utils
-from dp_utils import remove_dp_hooks
+from dp_utils import remove_dp_hooks, get_param_block
 import warnings
 from data.class_mappings import fine_id_coarse_id, coarse_id_fine_id, coarse_split
 
@@ -1470,7 +1470,7 @@ if __name__ == '__main__':
                     for name in layer_mean_scales:
                         if '.bn' in name or name.endswith('.bias'):
                             continue
-                        block = name.split('.')[0]
+                        block = get_param_block(name)
                         depth = BLOCK_DEPTH.get(block, 0)
                         target = args.dp_target_mean_scale * (decay ** depth)
                         log_clip[name] = log_clip.get(name, math.log(layer_clips.get(name, args.dp_clip)))

--- a/main_text.py
+++ b/main_text.py
@@ -22,7 +22,7 @@ from utils import *
 from opacus import PrivacyEngine
 from opacus.grad_sample import GradSampleModule
 import dp_utils
-from dp_utils import remove_dp_hooks
+from dp_utils import remove_dp_hooks, get_param_block
 import warnings
 from data.class_mappings import fine_id_coarse_id, coarse_id_fine_id, coarse_split
 
@@ -1429,7 +1429,7 @@ if __name__ == '__main__':
                     for name in layer_mean_scales:
                         if '.bn' in name or name.endswith('.bias'):
                             continue
-                        block = name.split('.')[0]
+                        block = get_param_block(name)
                         depth = BLOCK_DEPTH.get(block, 0)
                         target = args.dp_target_mean_scale * (decay ** depth)
                         log_clip[name] = log_clip.get(name, math.log(layer_clips.get(name, args.dp_clip)))

--- a/tests/test_param_block_decay.py
+++ b/tests/test_param_block_decay.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from dp_utils import get_param_block
+
+BLOCK_DEPTH = {'layer1': 0, 'layer2': 1, 'layer3': 2, 'layer4': 3, 'fc': 3, 'head': 3}
+
+
+def test_prefixed_module_decay_applies():
+    """Parameters with prefixes should decay based on internal block."""
+    name = 'encoder.layer3.0.conv.weight'
+    decay = 0.5
+    base_target = 1.0
+    block = get_param_block(name)
+    depth = BLOCK_DEPTH.get(block, 0)
+    target = base_target * (decay ** depth)
+    assert target == base_target * (decay ** 2)


### PR DESCRIPTION
## Summary
- add helper to extract depth-aware block prefix from parameter names
- apply helper in DP clip adaptation for image and text models
- test decay handling for prefixed module parameters

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python tests/test_param_block_decay.py`


------
https://chatgpt.com/codex/tasks/task_e_68c038aba804832a884bdfe990c55ac9