### PR TITLE
Log representative noise std

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The repository now includes optional support for a **personalised transformation
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)
   * `--print_eps`: output the current ε after each communication round when set to `1`
   * ε uses the minimum σ<sub>l</sub> across layers when noise multipliers differ
+  * per-round noise statistics are written to `*_noise.csv`; `noise_std_rep` is the mean per-parameter noise standard deviation derived from the current layer clips and noise multipliers (after step scaling) and `noise_norm` is the total L2 norm of the sampled noise
 
 Examples:
 

--- a/dp_utils.py
+++ b/dp_utils.py
@@ -7,6 +7,8 @@ except Exception:  # pragma: no cover - optional dependency
         """Fallback stub when Opacus is unavailable."""
         pass
 
+import numpy as np
+
 
 BLOCK_PREFIXES = ('layer1', 'layer2', 'layer3', 'layer4', 'fc', 'head')
 
@@ -29,6 +31,43 @@ def get_param_block(name):
         if token in BLOCK_PREFIXES:
             return token
     return None
+
+
+def aggregate_noise_std(layer_clips, noise_multipliers, num_clients, dp_noise, dp_constant_noise, agg='mean'):
+    """Return an aggregate of per-parameter noise standard deviations.
+
+    Parameters
+    ----------
+    layer_clips : dict[str, float]
+        Mapping from parameter names to clipping thresholds.
+    noise_multipliers : dict[str, float] | None
+        Optional per-parameter noise multipliers.
+    num_clients : int
+        Number of participating clients in the round.
+    dp_noise : float
+        Default noise multiplier.
+    dp_constant_noise : bool
+        ``True`` when noise does not scale with the clip.
+    agg : str, optional
+        Aggregation mode: ``'mean'`` (default) or ``'max'``.
+
+    Returns
+    -------
+    float
+        Representative noise standard deviation across parameters.
+    """
+    noise_stds = []
+    for name, clip in layer_clips.items():
+        if '.bn' in name or name.endswith('.bias'):
+            continue
+        mult = dp_noise
+        if noise_multipliers is not None:
+            mult = noise_multipliers.get(name, dp_noise)
+        std = mult / num_clients if dp_constant_noise else mult * clip / num_clients
+        noise_stds.append(std)
+    if not noise_stds:
+        return 0.0
+    return float(np.max(noise_stds)) if agg == 'max' else float(np.mean(noise_stds))
 
 
 def remove_dp_hooks(model):

--- a/main_image.py
+++ b/main_image.py
@@ -22,7 +22,7 @@ from utils import *
 from opacus import PrivacyEngine
 from opacus.grad_sample import GradSampleModule
 import dp_utils
-from dp_utils import remove_dp_hooks, get_param_block
+from dp_utils import remove_dp_hooks, get_param_block, aggregate_noise_std
 import warnings
 from data.class_mappings import fine_id_coarse_id, coarse_id_fine_id, coarse_split
 
@@ -1252,7 +1252,7 @@ if __name__ == '__main__':
 
     noise_csv_path = os.path.join(args.logdir, args.log_file_name + '_noise.csv')
     with open(noise_csv_path, 'w', newline='') as f:
-        csv.writer(f).writerow(['round', 'noise_std', 'noise_norm'])
+        csv.writer(f).writerow(['round', 'noise_std_rep', 'noise_norm'])
 
     seed = args.init_seed
     if args.dataset=='20newsgroup':
@@ -1419,7 +1419,7 @@ if __name__ == '__main__':
                 dp_steps += 1
             eta_eff = args.server_lr
             r_k = 1.0
-            noise_std = 0.0
+            noise_std_rep = 0.0
             noise_norm = 0.0
             if args.dp_mode == 'server':
                 if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
@@ -1452,7 +1452,9 @@ if __name__ == '__main__':
                 _, mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms, r_k, noise_norm = aggregate_deltas(
                     global_w, deltas, client_norms, client_scales, args, layer_clips, noise_multipliers
                 )
-                noise_std = args.dp_noise * (args.dp_clip / len(participating_ids)) * r_k
+                noise_std_rep = aggregate_noise_std(
+                    layer_clips, noise_multipliers, len(participating_ids), args.dp_noise, args.dp_constant_noise
+                ) * r_k
                 logging.info('Aggregate mean scale (incl client): %.4f', mean_scale)
                 logging.info('Client mean scale: %.4f', float(np.mean(list(client_scales.values()))))
                 decay = 0.9
@@ -1498,10 +1500,10 @@ if __name__ == '__main__':
                                 continue
                             global_w[key] += net_para[key] * fed_avg_freqs[net_id]
 
-            print(f'Noise std={noise_std:.3e}, noise L2={noise_norm:.3e}')
-            logger.info('Noise std=%.3e, noise L2=%.3e', noise_std, noise_norm)
+            print(f'Noise std={noise_std_rep:.3e}, noise L2={noise_norm:.3e}')
+            logger.info('Noise std=%.3e, noise L2=%.3e', noise_std_rep, noise_norm)
             with open(noise_csv_path, 'a', newline='') as f:
-                csv.writer(f).writerow([comm_round, noise_std, noise_norm])
+                csv.writer(f).writerow([comm_round, noise_std_rep, noise_norm])
 
             rescale_history.append(r_k)
             min_r = min(min_r, r_k)

--- a/main_text.py
+++ b/main_text.py
@@ -22,7 +22,7 @@ from utils import *
 from opacus import PrivacyEngine
 from opacus.grad_sample import GradSampleModule
 import dp_utils
-from dp_utils import remove_dp_hooks, get_param_block
+from dp_utils import remove_dp_hooks, get_param_block, aggregate_noise_std
 import warnings
 from data.class_mappings import fine_id_coarse_id, coarse_id_fine_id, coarse_split
 
@@ -1211,7 +1211,7 @@ if __name__ == '__main__':
 
     noise_csv_path = os.path.join(args.logdir, args.log_file_name + '_noise.csv')
     with open(noise_csv_path, 'w', newline='') as f:
-        csv.writer(f).writerow(['round', 'noise_std', 'noise_norm'])
+        csv.writer(f).writerow(['round', 'noise_std_rep', 'noise_norm'])
 
     seed = args.init_seed
     if args.dataset=='20newsgroup':
@@ -1378,7 +1378,7 @@ if __name__ == '__main__':
                 dp_steps += 1
             eta_eff = args.server_lr
             r_k = 1.0
-            noise_std = 0.0
+            noise_std_rep = 0.0
             noise_norm = 0.0
             if args.dp_mode == 'server':
                 if args.dp_bootstrap and not getattr(args, 'bootstrap_done', False):
@@ -1411,7 +1411,9 @@ if __name__ == '__main__':
                 _, mean_norm, median_norm, mean_scale, eta_eff, layer_mean_scales, layer_mean_norms, r_k, noise_norm = aggregate_deltas(
                     global_w, deltas, client_norms, client_scales, args, layer_clips, noise_multipliers
                 )
-                noise_std = args.dp_noise * (args.dp_clip / len(participating_ids)) * r_k
+                noise_std_rep = aggregate_noise_std(
+                    layer_clips, noise_multipliers, len(participating_ids), args.dp_noise, args.dp_constant_noise
+                ) * r_k
                 logging.info('Aggregate mean scale (incl client): %.4f', mean_scale)
                 logging.info('Client mean scale: %.4f', float(np.mean(list(client_scales.values()))))
                 decay = 0.9
@@ -1456,10 +1458,10 @@ if __name__ == '__main__':
                                 continue
                             global_w[key] += net_para[key] * fed_avg_freqs[net_id]
 
-            print(f'Noise std={noise_std:.3e}, noise L2={noise_norm:.3e}')
-            logger.info('Noise std=%.3e, noise L2=%.3e', noise_std, noise_norm)
+            print(f'Noise std={noise_std_rep:.3e}, noise L2={noise_norm:.3e}')
+            logger.info('Noise std=%.3e, noise L2=%.3e', noise_std_rep, noise_norm)
             with open(noise_csv_path, 'a', newline='') as f:
-                csv.writer(f).writerow([comm_round, noise_std, noise_norm])
+                csv.writer(f).writerow([comm_round, noise_std_rep, noise_norm])
 
             rescale_history.append(r_k)
             min_r = min(min_r, r_k)


### PR DESCRIPTION
## Summary
- compute mean per-parameter noise std via `aggregate_noise_std`
- log representative noise std and noise L2 norm to CSV
- document meaning of noise statistics in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests/test_step_cap_noise.py` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68c0396f55e0832aabf89a562e634107