### PR TITLE
Add option to disable client clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The repository now includes optional support for a **personalised transformation
   * `--dp_k_min`: floor multiplier for per-layer norms (default `0.2`)
   * `--dp_init_scale`: initial clip scaling (default `0.6`)
   * `--dp_clip_max`: maximum clip (default `0.8`)
+  * `--no_client_clipping`: disable per-client clipping while retaining server-side DP
   * `--dp_target_mean_scale`: desired mean clipping scale (default `0.6`)
   * `--dp_depth_decay`: exponential clip target decay per network depth (default `1.0`, e.g. `--dp_depth_decay=0.85` so deeper blocks get progressively tighter clip targets)
   * `--dp_adapt_gain`: adaptation gain (default `0.1`)

--- a/main_image.py
+++ b/main_image.py
@@ -227,6 +227,8 @@ def get_args():
     parser.add_argument('--dp_k_min', type=float, default=0.2, help='minimum clip multiplier relative to norm EMA')
     parser.add_argument('--dp_init_scale', type=float, default=0.6, help='initial clip scaling')
     parser.add_argument('--dp_clip_max', type=float, default=0.8, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--no_client_clipping', action='store_true',
+                        help='disable per-client update clipping')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--dp_noise', type=float, default=None, help='DP-SGD noise multiplier')
     group.add_argument('--dp_noise_scale', type=float, default=None, help='scale for DP noise as sigma = scale * clip')
@@ -927,7 +929,10 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                     )
                 ])
                 norm = torch.norm(flat).item()
-                scale = min(1.0, args.dp_clip / (norm + 1e-12))
+                if args.no_client_clipping:
+                    scale = 1.0
+                else:
+                    scale = min(1.0, args.dp_clip / (norm + 1e-12))
                 logging.info('Client %s norm %.4f scale %.4f', net_id, norm, scale)
                 prev = args.client_grad_norms.get(net_id, norm)
                 args.client_grad_norms[net_id] = grad_ma_decay * prev + (1 - grad_ma_decay) * norm

--- a/main_text.py
+++ b/main_text.py
@@ -217,6 +217,8 @@ def get_args():
     parser.add_argument('--dp_k_min', type=float, default=0.2, help='minimum clip multiplier relative to norm EMA')
     parser.add_argument('--dp_init_scale', type=float, default=0.6, help='initial clip scaling')
     parser.add_argument('--dp_clip_max', type=float, default=0.8, help='maximum DP-SGD clipping norm')
+    parser.add_argument('--no_client_clipping', action='store_true',
+                        help='disable per-client update clipping')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--dp_noise', type=float, default=None, help='DP-SGD noise multiplier')
     group.add_argument('--dp_noise_scale', type=float, default=None, help='scale for DP noise as sigma = scale * clip')
@@ -895,7 +897,10 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                     )
                 ])
                 norm = torch.norm(flat).item()
-                scale = min(1.0, args.dp_clip / (norm + 1e-12))
+                if args.no_client_clipping:
+                    scale = 1.0
+                else:
+                    scale = min(1.0, args.dp_clip / (norm + 1e-12))
                 logging.info('Client %s norm %.4f scale %.4f', net_id, norm, scale)
                 prev = args.client_grad_norms.get(net_id, norm)
                 args.client_grad_norms[net_id] = grad_ma_decay * prev + (1 - grad_ma_decay) * norm


### PR DESCRIPTION
## Summary
- add `--no_client_clipping` to skip per-client update clipping
- support unscaled client updates while retaining server-side differential privacy
- document optional client-clipping toggle in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c0f13ee1f0832a9943b290f1ca4132