### PR TITLE
Fix return values in pre-clip aggregation

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -1125,7 +1125,7 @@ def aggregate_deltas(
         avg_norm_sq += avg_update.pow(2).sum().item()
 
     if pre_clip_only:
-        return avg_updates, mean_norm, median_norm, mean_scale, 0.0, layer_mean_scales, layer_mean_norms, 1.0, 0.0
+        return avg_updates, mean_norm, median_norm, mean_scale, layer_mean_scales, layer_mean_norms, 1.0, 0.0
 
     avg_norm = avg_norm_sq ** 0.5
     raw_noise_norm = torch.sqrt(sum(v.pow(2).sum() for v in noise_terms.values()))

--- a/main_text.py
+++ b/main_text.py
@@ -1093,7 +1093,7 @@ def aggregate_deltas(
         avg_norm_sq += avg_update.pow(2).sum().item()
 
     if pre_clip_only:
-        return avg_updates, mean_norm, median_norm, mean_scale, 0.0, layer_mean_scales, layer_mean_norms, 1.0, 0.0
+        return avg_updates, mean_norm, median_norm, mean_scale, layer_mean_scales, layer_mean_norms, 1.0, 0.0
 
     avg_norm = avg_norm_sq ** 0.5
     raw_noise_norm = torch.sqrt(sum(v.pow(2).sum() for v in noise_terms.values()))


### PR DESCRIPTION
## Summary
- remove unused placeholder from `aggregate_deltas` when `pre_clip_only=True`
- ensure pre-clip calls still unpack eight values

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c107d0ef6c832ab7dcbf28329b1ea9