### PR TITLE
Include grad and noise accumulators in train_epoch

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -478,7 +478,7 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
     try:
 
         def train_epoch(epoch, mode='train'):
-            nonlocal dp_optimizer, head_optimizer, dp_scheduler, head_scheduler, tl_optimizer, gmodel, base_model, last_loss
+            nonlocal dp_optimizer, head_optimizer, dp_scheduler, head_scheduler, tl_optimizer, gmodel, base_model, last_loss, noise_accum, grad_accum
 
             def _has_grads(optimizer):
                 """Return True if any parameter of optimizer has a gradient."""


### PR DESCRIPTION
## Summary
- Ensure train_epoch can update noise and gradient accumulators by declaring them nonlocal

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
...` verifying noise_accum and grad_accum update without UnboundLocalError


------
https://chatgpt.com/codex/tasks/task_e_68c7c4ad08e0832a817d916dc224d60d