### PR TITLE
Filter server momentum deltas for local DP

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -1513,7 +1513,7 @@ if __name__ == '__main__':
                 epsilon = max(epsilons) if epsilons else 0.0
             if args.server_momentum and args.dp_mode != 'server':
                 if args.dp_mode == 'local':
-                    delta_w = avg_delta
+                    delta_w = {k: v for k, v in avg_delta.items() if k in moment_v}
                 else:
                     delta_w = {k: global_w[k] - old_w[k] for k in moment_v}
                 for key, dw in delta_w.items():


### PR DESCRIPTION
## Summary
- filter the local DP server momentum deltas to only include parameters tracked by the momentum state

## Testing
- python -m py_compile $(git ls-files '*.py')
- python main_image.py --dataset cifar10 *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c8eead7898832a94f55a009a760aa6