### PR TITLE
Add noise and gradient logging for local DP

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -892,11 +892,23 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                 norm = torch.norm(flat).item()
                 scale = min(1.0, args.dp_clip / (norm + 1e-12))
                 flat = flat * scale
+                grad_norm = torch.norm(flat).item()
                 noise = torch.normal(
                     0,
                     args.dp_noise * args.dp_clip,
                     size=flat.shape,
                     device=flat.device,
+                )
+                noise_norm = torch.norm(noise).item()
+                ratio = noise_norm / (grad_norm + 1e-12)
+                print(
+                    f'Client DP: noise L2={noise_norm:.3e}, grad L2={grad_norm:.3e}, noise/grad={ratio:.3e}'
+                )
+                logging.info(
+                    'Client DP: noise L2=%.3e, grad L2=%.3e, noise/grad=%.3e',
+                    noise_norm,
+                    grad_norm,
+                    ratio
                 )
                 flat = flat + noise
                 pointer = 0
@@ -905,6 +917,8 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                     delta[k] = flat[pointer:pointer + numel].view_as(v)
                     pointer += numel
                 deltas[net_id] = delta
+                client_noise[net_id] = noise_norm
+                client_grad[net_id] = grad_norm
         else:
             net.train()
             result, _, _, _, _ = train_net_few_shot_new(net_id, net, n_epoch, args.lr, args.optimizer, args, X_train_client, y_train_client, X_test, y_test,

--- a/main_text.py
+++ b/main_text.py
@@ -859,11 +859,23 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                 norm = torch.norm(flat).item()
                 scale = min(1.0, args.dp_clip / (norm + 1e-12))
                 flat = flat * scale
+                grad_norm = torch.norm(flat).item()
                 noise = torch.normal(
                     0,
                     args.dp_noise * args.dp_clip,
                     size=flat.shape,
                     device=flat.device,
+                )
+                noise_norm = torch.norm(noise).item()
+                ratio = noise_norm / (grad_norm + 1e-12)
+                print(
+                    f'Client DP: noise L2={noise_norm:.3e}, grad L2={grad_norm:.3e}, noise/grad={ratio:.3e}'
+                )
+                logging.info(
+                    'Client DP: noise L2=%.3e, grad L2=%.3e, noise/grad=%.3e',
+                    noise_norm,
+                    grad_norm,
+                    ratio
                 )
                 flat = flat + noise
                 pointer = 0
@@ -872,6 +884,8 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                     delta[k] = flat[pointer:pointer + numel].view_as(v)
                     pointer += numel
                 deltas[net_id] = delta
+                client_noise[net_id] = noise_norm
+                client_grad[net_id] = grad_norm
         else:
             net.train()
             result, _, _, _, _ = train_net_few_shot_new(net_id, net, n_epoch, args.lr, args.optimizer, args, X_train_client, y_train_client, X_test, y_test,


### PR DESCRIPTION
## Summary
- log L2 norms of gradients and noise when applying local DP
- report per-client noise/grad ratio during federated training

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c8f933c0c8832aba7f5362db1b7c5a