### PR TITLE
Log aggregated update norm for local DP

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -1457,6 +1457,13 @@ if __name__ == '__main__':
                         if key not in avg_delta:
                             avg_delta[key] = torch.zeros_like(val)
                         avg_delta[key] += val / num_clients  # uniform weighting; replace with counts if public
+                avg_delta_norm = (
+                    torch.norm(torch.cat([dw.view(-1) for dw in avg_delta.values()])).item()
+                    if avg_delta
+                    else 0.0
+                )
+                print(f'Aggregated update L2={avg_delta_norm:.6f}')
+                logger.info('Aggregated update L2=%.6f', avg_delta_norm)
                 noise_values = list(client_noise.values())
                 grad_values = list(client_grad.values())
                 mean_noise = float(np.mean(noise_values)) if noise_values else 0.0

--- a/main_text.py
+++ b/main_text.py
@@ -1425,6 +1425,13 @@ if __name__ == '__main__':
                         if key not in avg_delta:
                             avg_delta[key] = torch.zeros_like(val)
                         avg_delta[key] += val / num_clients  # uniform weighting; replace with counts if public
+                avg_delta_norm = (
+                    torch.norm(torch.cat([dw.view(-1) for dw in avg_delta.values()])).item()
+                    if avg_delta
+                    else 0.0
+                )
+                print(f'Aggregated update L2={avg_delta_norm:.6f}')
+                logger.info('Aggregated update L2=%.6f', avg_delta_norm)
                 noise_values = list(client_noise.values())
                 grad_values = list(client_grad.values())
                 mean_noise = float(np.mean(noise_values)) if noise_values else 0.0


### PR DESCRIPTION
## Summary
- Log aggregated update L2 norm during local-DP aggregation for image and text training scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68c900feeb4c832a914de3150ffeba1d