### PR TITLE
Add PRV accounting option for local DP

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The repository now includes optional support for a **personalised transformation
   * `--dp_bootstrap`: bootstrap clip from the first round's median norm (default `True`)
   * `--dp_noise`: fixed noise multiplier (default) **or** `--dp_noise_scale` to scale noise with the clip via `sigma = scale * clip`
   * `--dp_delta`: target delta for privacy accounting (default `1e-5`)
+  * `--dp_accountant`: privacy accountant used to estimate ε (`rdp` default). Set to `prv` to use the PRV accountant, which requires installing [`prv_accountant`](https://github.com/microsoft/prv_accountant) (e.g. `pip install prv-accountant`).
   * `--print_eps`: output the current ε after each communication round when set to `1`
   * ε uses the minimum σ<sub>l</sub> across layers when noise multipliers differ
   * per-round noise statistics are written to `*_noise.csv`; `noise_std_rep` is the mean per-parameter noise standard deviation derived from the current layer clips and noise multipliers (after step scaling) and `noise_norm` is the total L2 norm of the sampled noise

--- a/main_image.py
+++ b/main_image.py
@@ -1540,15 +1540,29 @@ if __name__ == '__main__':
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
             elif args.dp_mode == 'local':
-                orders = range(2, 257)
-                sig = args.dp_noise
-                delta = args.dp_delta
-                epsilons = []
-                for m in user_rounds.values():
-                    epsilons.append(
-                        min(m * a / (2 * sig ** 2) + math.log(1 / delta) / (a - 1) for a in orders)
-                    )
-                epsilon = max(epsilons) if epsilons else 0.0
+                if args.dp_accountant != 'prv':
+                    orders = range(2, 257)
+                    sig = args.dp_noise
+                    delta = args.dp_delta
+                    epsilons = []
+                    for m in user_rounds.values():
+                        epsilons.append(
+                            min(m * a / (2 * sig ** 2) + math.log(1 / delta) / (a - 1) for a in orders)
+                        )
+                    epsilon = max(epsilons) if epsilons else 0.0
+                else:
+                    epsilons = []
+                    for m in user_rounds.values():
+                        epsilons.append(
+                            dp_utils.compute_epsilon(
+                                m,
+                                args.dp_noise,
+                                args.dp_delta,
+                                accountant='prv',
+                                sampling_rate=1.0,
+                            )
+                        )
+                    epsilon = max(epsilons) if epsilons else 0.0
             if args.server_momentum and args.dp_mode != 'server':
                 if args.dp_mode == 'local':
                     delta_w = {k: v for k, v in avg_delta.items() if k in moment_v}

--- a/main_text.py
+++ b/main_text.py
@@ -1504,15 +1504,29 @@ if __name__ == '__main__':
                     sampling_rate=len(participating_ids) / args.n_parties,
                 )
             elif args.dp_mode == 'local':
-                orders = range(2, 257)
-                sig = args.dp_noise
-                delta = args.dp_delta
-                epsilons = []
-                for m in user_rounds.values():
-                    epsilons.append(
-                        min(m * a / (2 * sig ** 2) + math.log(1 / delta) / (a - 1) for a in orders)
-                    )
-                epsilon = max(epsilons) if epsilons else 0.0
+                if args.dp_accountant != 'prv':
+                    orders = range(2, 257)
+                    sig = args.dp_noise
+                    delta = args.dp_delta
+                    epsilons = []
+                    for m in user_rounds.values():
+                        epsilons.append(
+                            min(m * a / (2 * sig ** 2) + math.log(1 / delta) / (a - 1) for a in orders)
+                        )
+                    epsilon = max(epsilons) if epsilons else 0.0
+                else:
+                    epsilons = []
+                    for m in user_rounds.values():
+                        epsilons.append(
+                            dp_utils.compute_epsilon(
+                                m,
+                                args.dp_noise,
+                                args.dp_delta,
+                                accountant='prv',
+                                sampling_rate=1.0,
+                            )
+                        )
+                    epsilon = max(epsilons) if epsilons else 0.0
             if args.server_momentum and args.dp_mode != 'server':
                 if args.dp_mode == 'local':
                     delta_w = avg_delta


### PR DESCRIPTION
## Summary
- gate the existing local DP epsilon bound behind the default RDP accountant
- compute per-client epsilons with the PRV accountant when `--dp_accountant prv` is selected
- document that the `prv_accountant` package is required to use PRV-based accounting

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68c90f0e7218832ab71ab73e41f2d621