### PR TITLE
Apply DP clip deadband before adaptation

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -1462,6 +1462,9 @@ if __name__ == '__main__':
                         depth = BLOCK_DEPTH.get(block, 0)
                         target = args.dp_target_mean_scale * (decay ** depth)
                         log_clip[name] = log_clip.get(name, math.log(layer_clips.get(name, args.dp_clip)))
+                        adjustment = args.dp_target_mean_scale - scale_ema[name]
+                        if abs(adjustment) <= args.dp_deadband:
+                            continue
                         log_clip[name] += args.dp_adapt_gain * (target - scale_ema[name])
                         log_clip[name] = min(max(log_clip[name], math.log(clip_min[name])), math.log(args.dp_clip_max))
                         layer_clips[name] = math.exp(log_clip[name])
@@ -1581,6 +1584,8 @@ if __name__ == '__main__':
                             base = layer_clips.get(name, args.dp_clip)
                             log_clip[name] = log_clip.get(name, math.log(base))
                             adjustment = args.dp_target_mean_scale - scale_ema[name]
+                            if abs(adjustment) <= args.dp_deadband:
+                                continue
                             log_clip[name] += args.dp_adapt_gain * adjustment
                             lower = math.log(clip_min[name])
                             upper = math.log(args.dp_clip_max)

--- a/main_text.py
+++ b/main_text.py
@@ -1430,6 +1430,9 @@ if __name__ == '__main__':
                         depth = BLOCK_DEPTH.get(block, 0)
                         target = args.dp_target_mean_scale * (decay ** depth)
                         log_clip[name] = log_clip.get(name, math.log(layer_clips.get(name, args.dp_clip)))
+                        adjustment = args.dp_target_mean_scale - scale_ema[name]
+                        if abs(adjustment) <= args.dp_deadband:
+                            continue
                         log_clip[name] += args.dp_adapt_gain * (target - scale_ema[name])
                         log_clip[name] = min(max(log_clip[name], math.log(clip_min[name])), math.log(args.dp_clip_max))
                         layer_clips[name] = math.exp(log_clip[name])
@@ -1549,6 +1552,8 @@ if __name__ == '__main__':
                             base = layer_clips.get(name, args.dp_clip)
                             log_clip[name] = log_clip.get(name, math.log(base))
                             adjustment = args.dp_target_mean_scale - scale_ema[name]
+                            if abs(adjustment) <= args.dp_deadband:
+                                continue
                             log_clip[name] += args.dp_adapt_gain * adjustment
                             lower = math.log(clip_min[name])
                             upper = math.log(args.dp_clip_max)


### PR DESCRIPTION
## Summary
- gate per-layer DP clip adjustments on `dp_deadband` inside the server adaptation loops for image and text training scripts
- apply the same deadband guard when adapting per-layer clips during local DP aggregation

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68c94b8c3b58832a80f36c4a282d67f8