### PR TITLE
Update local DP aggregation logging

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -1608,7 +1608,9 @@ if __name__ == '__main__':
                 noise_rss = math.sqrt(sum(v ** 2 for v in noise_values)) if noise_values else 0.0
                 grad_rss = math.sqrt(sum(v ** 2 for v in grad_values)) if grad_values else 0.0
                 aggregated_noise = noise_rss / client_count
-                aggregated_grad = grad_rss / client_count
+                signal_sq = max(avg_delta_norm ** 2 - aggregated_noise ** 2, 0.0)
+                aggregated_grad = math.sqrt(signal_sq)
+                per_client_grad_rms = grad_rss / client_count if grad_values else 0.0
                 aggregated_noise_grad_ratio = aggregated_noise / (aggregated_grad + 1e-12)
                 scaled_aggregated_noise = r_k * aggregated_noise
                 scaled_aggregated_grad = r_k * aggregated_grad
@@ -1639,6 +1641,9 @@ if __name__ == '__main__':
                     scaled_aggregated_grad,
                     scaled_aggregated_noise_grad_ratio,
                 )
+                if grad_values:
+                    print('Client DP diagnostic: per-client grad RMS L2={:.6f}'.format(per_client_grad_rms))
+                    logger.info('Client DP diagnostic: per-client grad RMS L2=%.6f', per_client_grad_rms)
                 if per_layer_updates:
                     decay = 0.9
                     rms_values = []

--- a/main_text.py
+++ b/main_text.py
@@ -1526,40 +1526,48 @@ if __name__ == '__main__':
                 logger.info('Aggregated update L2 (pre-scale)=%.6f', avg_delta_norm)
                 print(f'Local step L2={step_norm:.6f}, r_k={r_k:.4f} ({cap_state})')
                 logger.info('Local step L2=%.6f, r_k=%.4f (%s)', step_norm, r_k, cap_state)
-                noise_values = list(client_noise.values())
-                grad_values = list(client_grad.values())
-                mean_noise = float(np.mean(noise_values)) if noise_values else 0.0
-                mean_grad = float(np.mean(grad_values)) if grad_values else 0.0
-                noise_grad_ratio = mean_noise / (mean_grad + 1e-12)
-                scaled_mean_noise = r_k * mean_noise
-                scaled_mean_grad = r_k * mean_grad
-                scaled_noise_grad_ratio = scaled_mean_noise / (scaled_mean_grad + 1e-12)
+                noise_values = [float(v) for v in client_noise.values()]
+                grad_values = [float(v) for v in client_grad.values()]
+                client_count = max(num_clients, 1)
+                noise_rss = math.sqrt(sum(v ** 2 for v in noise_values)) if noise_values else 0.0
+                grad_rss = math.sqrt(sum(v ** 2 for v in grad_values)) if grad_values else 0.0
+                aggregated_noise = noise_rss / client_count
+                signal_sq = max(avg_delta_norm ** 2 - aggregated_noise ** 2, 0.0)
+                aggregated_grad = math.sqrt(signal_sq)
+                per_client_grad_rms = grad_rss / client_count if grad_values else 0.0
+                noise_grad_ratio = aggregated_noise / (aggregated_grad + 1e-12)
+                scaled_aggregated_noise = r_k * aggregated_noise
+                scaled_aggregated_grad = r_k * aggregated_grad
+                scaled_noise_grad_ratio = scaled_aggregated_noise / (scaled_aggregated_grad + 1e-12)
                 print(
                     'Client DP: noise L2={:.6f}, grad L2={:.6f}, noise/grad={:.6f}'.format(
-                        mean_noise,
-                        mean_grad,
+                        aggregated_noise,
+                        aggregated_grad,
                         noise_grad_ratio,
                     )
                 )
                 logger.info(
                     'Client DP: noise L2=%.6f, grad L2=%.6f, noise/grad=%.6f',
-                    mean_noise,
-                    mean_grad,
+                    aggregated_noise,
+                    aggregated_grad,
                     noise_grad_ratio,
                 )
                 print(
                     'Client DP (scaled): noise L2={:.6f}, grad L2={:.6f}, noise/grad={:.6f}'.format(
-                        scaled_mean_noise,
-                        scaled_mean_grad,
+                        scaled_aggregated_noise,
+                        scaled_aggregated_grad,
                         scaled_noise_grad_ratio,
                     )
                 )
                 logger.info(
                     'Client DP (scaled): noise L2=%.6f, grad L2=%.6f, noise/grad=%.6f',
-                    scaled_mean_noise,
-                    scaled_mean_grad,
+                    scaled_aggregated_noise,
+                    scaled_aggregated_grad,
                     scaled_noise_grad_ratio,
                 )
+                if grad_values:
+                    print('Client DP diagnostic: per-client grad RMS L2={:.6f}'.format(per_client_grad_rms))
+                    logger.info('Client DP diagnostic: per-client grad RMS L2=%.6f', per_client_grad_rms)
                 if per_layer_updates:
                     decay = 0.9
                     rms_values = []
@@ -1634,8 +1642,8 @@ if __name__ == '__main__':
                 with open(noise_csv_path, 'a', newline='') as f:
                     csv.writer(f).writerow([
                         comm_round,
-                        f'{mean_noise:.6f}',
-                        f'{mean_grad:.6f}',
+                        f'{aggregated_noise:.6f}',
+                        f'{aggregated_grad:.6f}',
                         f'{noise_grad_ratio:.6f}',
                     ])
             else:


### PR DESCRIPTION
## Summary
- derive the aggregated gradient magnitude from the capped average update after removing the estimated noise power in both image and text local-DP pipelines
- log the updated gradient, noise, and ratio metrics along with an auxiliary per-client RMS diagnostic to reflect the new aggregation interpretation
- record the revised aggregated statistics in the text pipeline's CSV output for downstream analysis

## Testing
- python -m py_compile $(git ls-files '*.py')


------
https://chatgpt.com/codex/tasks/task_e_68ca4abf0654832aa908eb66804572db