### PR TITLE
Track clipped updates for local DP aggregation

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -883,6 +883,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
     client_scales = {}
     client_noise = {}
     client_grad = {}
+    clipped_updates: dict[str, dict[str, torch.Tensor]] = {}
     if args.dp_mode == 'server' and not hasattr(args, 'client_grad_norms'):
         args.client_grad_norms = {}
     grad_ma_decay = 0.9
@@ -953,6 +954,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                     if not any(exempt in k for exempt in EXEMPT_NAMES)
                 }
                 noised_delta: dict[str, torch.Tensor] = {}
+                client_clipped: dict[str, torch.Tensor] = {}
                 grad_sq = 0.0
                 noise_sq = 0.0
                 protected_params = 0
@@ -982,6 +984,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                             scale,
                         )
                     clipped = update * scale
+                    client_clipped[name] = clipped.detach()
                     grad_sq += clipped.pow(2).sum().item()
                     sigma = noise_multipliers.get(name, args.dp_noise)
                     noise_std = sigma if args.dp_constant_noise else sigma * clip
@@ -993,6 +996,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                     noised_delta[name] = clipped + noise
                     protected_params += 1
                 deltas[net_id] = noised_delta
+                clipped_updates[net_id] = client_clipped
                 client_noise[net_id] = math.sqrt(noise_sq)
                 client_grad[net_id] = math.sqrt(grad_sq)
                 logging.info(
@@ -1043,7 +1047,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
     if args.dp_mode == 'server':
         return deltas, client_norms, client_scales, client_noise, client_grad, epsilon, avg_loss
     if args.dp_mode == 'local':
-        return deltas, client_noise, client_grad, epsilon, avg_loss
+        return deltas, clipped_updates, client_noise, client_grad, epsilon, avg_loss
     return nets, epsilon, avg_loss
 
 
@@ -1486,7 +1490,7 @@ if __name__ == '__main__':
                     nets_this_round, args, net_dataidx_map, X_train, y_train, X_test, y_test, device=device
                 )
             elif args.dp_mode == 'local':
-                deltas, client_noise, client_grad, _, round_loss = local_train_net_few_shot(
+                deltas, clipped_updates, client_noise, client_grad, _, round_loss = local_train_net_few_shot(
                     nets_this_round, args, net_dataidx_map, X_train, y_train, X_test, y_test, device=device
                 )
             else:
@@ -1567,6 +1571,7 @@ if __name__ == '__main__':
                 logging.info('layer_mean_scales: %s', layer_mean_scales)
             elif args.dp_mode == 'local':
                 avg_delta: dict[str, torch.Tensor] = {}
+                avg_clipped: dict[str, torch.Tensor] = {}
                 per_layer_updates: dict[str, list[torch.Tensor]] = {}
                 num_clients = len(deltas)
                 for delta in deltas.values():
@@ -1575,7 +1580,7 @@ if __name__ == '__main__':
                             continue
                         if key not in avg_delta:
                             avg_delta[key] = torch.zeros_like(val)
-                        avg_delta[key] += val / max(num_clients, 1)  # uniform weighting; replace with counts if public
+                        avg_delta[key] += val / max(num_clients, 1)
                         if any(token in key for token in (
                             'running_mean',
                             'running_var',
@@ -1584,10 +1589,22 @@ if __name__ == '__main__':
                             continue
                         if key.endswith('.bias') or '.bn' in key:
                             continue
+                for delta in clipped_updates.values():
+                    for key, val in delta.items():
+                        if any(exempt in key for exempt in EXEMPT_NAMES):
+                            continue
+                        if key not in avg_clipped:
+                            avg_clipped[key] = torch.zeros_like(val)
+                        avg_clipped[key] += val / max(num_clients, 1)
                         per_layer_updates.setdefault(key, []).append(val.detach())
                 avg_delta_norm = (
                     torch.norm(torch.cat([dw.view(-1) for dw in avg_delta.values()])).item()
                     if avg_delta
+                    else 0.0
+                )
+                aggregated_grad = (
+                    torch.norm(torch.cat([dw.view(-1) for dw in avg_clipped.values()])).item()
+                    if avg_clipped
                     else 0.0
                 )
                 r_k = min(1.0, args.target_step / max(avg_delta_norm, 1e-12))
@@ -1601,15 +1618,14 @@ if __name__ == '__main__':
                 cap_state = 'cap=ON' if r_k < 1.0 else 'cap=off'
                 print(f'Aggregated update L2 (pre-scale)={avg_delta_norm:.6f}')
                 logger.info('Aggregated update L2 (pre-scale)=%.6f', avg_delta_norm)
+                print(f'Aggregated clipped grad L2={aggregated_grad:.6f}')
+                logger.info('Aggregated clipped grad L2=%.6f', aggregated_grad)
                 print(f'Local step L2={step_norm:.6f}, r_k={r_k:.4f} ({cap_state})')
                 logger.info('Local step L2=%.6f, r_k=%.4f (%s)', step_norm, r_k, cap_state)
                 noise_values = [float(v) for v in client_noise.values()]
-                grad_values = [float(v) for v in client_grad.values()]
                 client_count = max(num_clients, 1)
                 noise_rss = math.sqrt(sum(v ** 2 for v in noise_values)) if noise_values else 0.0
-                grad_rss = math.sqrt(sum(v ** 2 for v in grad_values)) if grad_values else 0.0
                 aggregated_noise = noise_rss / client_count
-                aggregated_grad = grad_rss / client_count
                 aggregated_noise_grad_ratio = aggregated_noise / (aggregated_grad + 1e-12)
                 scaled_aggregated_noise = r_k * aggregated_noise
                 scaled_aggregated_grad = r_k * aggregated_grad

--- a/main_text.py
+++ b/main_text.py
@@ -833,6 +833,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
     client_scales = {}
     client_noise = {}
     client_grad = {}
+    clipped_updates: dict[str, dict[str, torch.Tensor]] = {}
     if args.dp_mode == 'server' and not hasattr(args, 'client_grad_norms'):
         args.client_grad_norms = {}
     grad_ma_decay = 0.9
@@ -897,6 +898,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                     if 'few_classify' not in k and 'transform_layer' not in k
                 }
                 noised_delta: dict[str, torch.Tensor] = {}
+                client_clipped: dict[str, torch.Tensor] = {}
                 grad_sq = 0.0
                 noise_sq = 0.0
                 for name, update in delta.items():
@@ -917,6 +919,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                             scale,
                         )
                     clipped = update * scale
+                    client_clipped[name] = clipped.detach()
                     grad_sq += clipped.pow(2).sum().item()
                     sigma = noise_multipliers.get(name, args.dp_noise)
                     noise_std = sigma if args.dp_constant_noise else sigma * clip
@@ -927,6 +930,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
                         noise = torch.zeros_like(clipped)
                     noised_delta[name] = clipped + noise
                 deltas[net_id] = noised_delta
+                clipped_updates[net_id] = client_clipped
                 client_noise[net_id] = math.sqrt(noise_sq)
                 client_grad[net_id] = math.sqrt(grad_sq)
         else:
@@ -970,7 +974,7 @@ def local_train_net_few_shot(nets, args, net_dataidx_map, X_train, y_train, X_te
     if args.dp_mode == 'server':
         return deltas, client_norms, client_scales, client_noise, client_grad, epsilon, avg_loss
     if args.dp_mode == 'local':
-        return deltas, client_noise, client_grad, epsilon, avg_loss
+        return deltas, clipped_updates, client_noise, client_grad, epsilon, avg_loss
     return nets, epsilon, avg_loss
 
 
@@ -1234,7 +1238,7 @@ if __name__ == '__main__':
         if args.dp_mode == 'server':
             header.extend(['noise_std_rep', 'noise_norm'])
         elif args.dp_mode == 'local':
-            header.extend(['mean_noise_l2', 'mean_grad_l2', 'noise_grad_ratio'])
+            header.extend(['mean_noise_l2', 'aggregated_grad_l2', 'noise_grad_ratio'])
         csv.writer(f).writerow(header)
 
     seed = args.init_seed
@@ -1407,7 +1411,7 @@ if __name__ == '__main__':
                     nets_this_round, args, net_dataidx_map, X_train, y_train, X_test, y_test, device=device
                 )
             elif args.dp_mode == 'local':
-                deltas, client_noise, client_grad, _, round_loss = local_train_net_few_shot(
+                deltas, clipped_updates, client_noise, client_grad, _, round_loss = local_train_net_few_shot(
                     nets_this_round, args, net_dataidx_map, X_train, y_train, X_test, y_test, device=device
                 )
             else:
@@ -1491,13 +1495,19 @@ if __name__ == '__main__':
                 logging.info('layer_mean_scales: %s', layer_mean_scales)
             elif args.dp_mode == 'local':
                 avg_delta: dict[str, torch.Tensor] = {}
+                avg_clipped: dict[str, torch.Tensor] = {}
                 per_layer_updates: dict[str, list[torch.Tensor]] = {}
                 num_clients = len(deltas)
                 for delta in deltas.values():
                     for key, val in delta.items():
                         if key not in avg_delta:
                             avg_delta[key] = torch.zeros_like(val)
-                        avg_delta[key] += val / max(num_clients, 1)  # uniform weighting; replace with counts if public
+                        avg_delta[key] += val / max(num_clients, 1)
+                for delta in clipped_updates.values():
+                    for key, val in delta.items():
+                        if key not in avg_clipped:
+                            avg_clipped[key] = torch.zeros_like(val)
+                        avg_clipped[key] += val / max(num_clients, 1)
                         if any(token in key for token in (
                             'running_mean',
                             'running_var',
@@ -1514,6 +1524,11 @@ if __name__ == '__main__':
                     if avg_delta
                     else 0.0
                 )
+                aggregated_grad = (
+                    torch.norm(torch.cat([dw.view(-1) for dw in avg_clipped.values()])).item()
+                    if avg_clipped
+                    else 0.0
+                )
                 r_k = min(1.0, args.target_step / max(avg_delta_norm, 1e-12))
                 for key in avg_delta:
                     avg_delta[key] = avg_delta[key] * r_k
@@ -1525,40 +1540,40 @@ if __name__ == '__main__':
                 cap_state = 'cap=ON' if r_k < 1.0 else 'cap=off'
                 print(f'Aggregated update L2 (pre-scale)={avg_delta_norm:.6f}')
                 logger.info('Aggregated update L2 (pre-scale)=%.6f', avg_delta_norm)
+                print(f'Aggregated clipped grad L2={aggregated_grad:.6f}')
+                logger.info('Aggregated clipped grad L2=%.6f', aggregated_grad)
                 print(f'Local step L2={step_norm:.6f}, r_k={r_k:.4f} ({cap_state})')
                 logger.info('Local step L2=%.6f, r_k=%.4f (%s)', step_norm, r_k, cap_state)
                 noise_values = list(client_noise.values())
-                grad_values = list(client_grad.values())
                 mean_noise = float(np.mean(noise_values)) if noise_values else 0.0
-                mean_grad = float(np.mean(grad_values)) if grad_values else 0.0
-                noise_grad_ratio = mean_noise / (mean_grad + 1e-12)
+                noise_grad_ratio = mean_noise / (aggregated_grad + 1e-12)
                 scaled_mean_noise = r_k * mean_noise
-                scaled_mean_grad = r_k * mean_grad
-                scaled_noise_grad_ratio = scaled_mean_noise / (scaled_mean_grad + 1e-12)
+                scaled_aggregated_grad = r_k * aggregated_grad
+                scaled_noise_grad_ratio = scaled_mean_noise / (scaled_aggregated_grad + 1e-12)
                 print(
                     'Client DP: noise L2={:.6f}, grad L2={:.6f}, noise/grad={:.6f}'.format(
                         mean_noise,
-                        mean_grad,
+                        aggregated_grad,
                         noise_grad_ratio,
                     )
                 )
                 logger.info(
                     'Client DP: noise L2=%.6f, grad L2=%.6f, noise/grad=%.6f',
                     mean_noise,
-                    mean_grad,
+                    aggregated_grad,
                     noise_grad_ratio,
                 )
                 print(
                     'Client DP (scaled): noise L2={:.6f}, grad L2={:.6f}, noise/grad={:.6f}'.format(
                         scaled_mean_noise,
-                        scaled_mean_grad,
+                        scaled_aggregated_grad,
                         scaled_noise_grad_ratio,
                     )
                 )
                 logger.info(
                     'Client DP (scaled): noise L2=%.6f, grad L2=%.6f, noise/grad=%.6f',
                     scaled_mean_noise,
-                    scaled_mean_grad,
+                    scaled_aggregated_grad,
                     scaled_noise_grad_ratio,
                 )
                 if per_layer_updates:
@@ -1636,7 +1651,7 @@ if __name__ == '__main__':
                     csv.writer(f).writerow([
                         comm_round,
                         f'{mean_noise:.6f}',
-                        f'{mean_grad:.6f}',
+                        f'{aggregated_grad:.6f}',
                         f'{noise_grad_ratio:.6f}',
                     ])
             else:


### PR DESCRIPTION
## Summary
- retain per-client clipped parameter deltas during local DP training so they can be reused after noise is applied
- average the clipped updates during aggregation to log the aggregate gradient L2 norm and write it to the CSV outputs

## Testing
- python -m py_compile $(git ls-files '*.py')


------
https://chatgpt.com/codex/tasks/task_e_68ca50b17824832a83435a5cfaa27667