### PR TITLE
Exclude BN and bias tensors from local DP updates

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -1375,8 +1375,9 @@ if __name__ == '__main__':
     layer_clips.clear()
     layer_clips.update({
         name: args.dp_clip
-        for name in global_model.state_dict()
+        for name, tensor in global_model.state_dict().items()
         if not any(e in name for e in EXEMPT_NAMES)
+        and not _is_bn_or_bias(name, tensor)
     })
     sentinel_layers.clear()
     sentinel_layers.update(determine_sentinel_layers(layer_clips))
@@ -1578,6 +1579,8 @@ if __name__ == '__main__':
                     for key, val in delta.items():
                         if any(exempt in key for exempt in EXEMPT_NAMES):
                             continue
+                        if _is_bn_or_bias(key, val):
+                            continue
                         if key not in avg_delta:
                             avg_delta[key] = torch.zeros_like(val)
                         avg_delta[key] += val / max(num_clients, 1)
@@ -1587,15 +1590,21 @@ if __name__ == '__main__':
                             'num_batches_tracked',
                         )):
                             continue
-                        if key.endswith('.bias') or '.bn' in key:
-                            continue
                 for delta in clipped_updates.values():
                     for key, val in delta.items():
                         if any(exempt in key for exempt in EXEMPT_NAMES):
                             continue
+                        if _is_bn_or_bias(key, val):
+                            continue
                         if key not in avg_clipped:
                             avg_clipped[key] = torch.zeros_like(val)
                         avg_clipped[key] += val / max(num_clients, 1)
+                        if any(token in key for token in (
+                            'running_mean',
+                            'running_var',
+                            'num_batches_tracked',
+                        )):
+                            continue
                         per_layer_updates.setdefault(key, []).append(val.detach())
                 avg_delta_norm = (
                     torch.norm(torch.cat([dw.view(-1) for dw in avg_delta.values()])).item()
@@ -1829,6 +1838,8 @@ if __name__ == '__main__':
             elif args.dp_mode == 'local' and old_w is not None:
                 for key, dw in avg_delta.items():
                     if any(exempt in key for exempt in EXEMPT_NAMES):
+                        continue
+                    if _is_bn_or_bias(key, dw):
                         continue
                     global_w[key] = old_w[key] + dw
 

--- a/main_text.py
+++ b/main_text.py
@@ -46,6 +46,11 @@ EXEMPT_NAMES = ('transformer', 'few_classify', 'transform_layer')
 REFERENCE_SHOT = 5
 
 
+def _is_bn_or_bias(name: str, tensor: torch.Tensor) -> bool:
+    """Return ``True`` when ``tensor`` belongs to a BatchNorm weight/bias."""
+    return '.bn' in name or name.endswith('.bias') or tensor.dim() == 1
+
+
 def clamp(value: int, min_value: int, max_value: int) -> int:
     """Clamp value within the inclusive range [min_value, max_value]."""
     return max(min_value, min(value, max_value))
@@ -1007,9 +1012,6 @@ def aggregate_deltas(
         layer_mean_scales, layer_mean_norms, r_k, noise_norm
     """
 
-    def _is_bn_or_bias(name: str, tensor: torch.Tensor) -> bool:
-        return '.bn' in name or name.endswith('.bias') or tensor.dim() == 1
-
     clipped = []
     scales = []
     norms = []
@@ -1296,8 +1298,9 @@ if __name__ == '__main__':
     layer_clips.clear()
     layer_clips.update({
         name: args.dp_clip
-        for name in global_model.state_dict()
+        for name, tensor in global_model.state_dict().items()
         if not any(e in name for e in EXEMPT_NAMES)
+        and not _is_bn_or_bias(name, tensor)
     })
     sentinel_layers.clear()
     sentinel_layers.update(determine_sentinel_layers(layer_clips))
@@ -1500,11 +1503,19 @@ if __name__ == '__main__':
                 num_clients = len(deltas)
                 for delta in deltas.values():
                     for key, val in delta.items():
+                        if any(exempt in key for exempt in EXEMPT_NAMES):
+                            continue
+                        if _is_bn_or_bias(key, val):
+                            continue
                         if key not in avg_delta:
                             avg_delta[key] = torch.zeros_like(val)
                         avg_delta[key] += val / max(num_clients, 1)
                 for delta in clipped_updates.values():
                     for key, val in delta.items():
+                        if any(exempt in key for exempt in EXEMPT_NAMES):
+                            continue
+                        if _is_bn_or_bias(key, val):
+                            continue
                         if key not in avg_clipped:
                             avg_clipped[key] = torch.zeros_like(val)
                         avg_clipped[key] += val / max(num_clients, 1)
@@ -1513,10 +1524,6 @@ if __name__ == '__main__':
                             'running_var',
                             'num_batches_tracked',
                         )):
-                            continue
-                        if key.endswith('.bias') or '.bn' in key:
-                            continue
-                        if any(exempt in key for exempt in EXEMPT_NAMES):
                             continue
                         per_layer_updates.setdefault(key, []).append(val.detach())
                 avg_delta_norm = (
@@ -1733,6 +1740,10 @@ if __name__ == '__main__':
                     moment_v[key] = args.server_momentum * moment_v[key] + (1 - args.server_momentum) * dw
             elif args.dp_mode == 'local' and old_w is not None:
                 for key, dw in avg_delta.items():
+                    if any(exempt in key for exempt in EXEMPT_NAMES):
+                        continue
+                    if _is_bn_or_bias(key, dw):
+                        continue
                     global_w[key] = old_w[key] + dw
                 unscaled_moment_norm = 0.0
                 for v in moment_v.values():


### PR DESCRIPTION
## Summary
- filter BatchNorm and bias parameters out of the initial layer clipping setup for both image and text training paths
- stop BN/bias tensors from contributing to local-DP averaged updates and per-layer statistics, and skip writing them back to the global model

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68ca67cf14a8832a9e875a09039594e2