### PR TITLE
Add optional transform layer support for text model

### DIFF
--- a/main_text.py
+++ b/main_text.py
@@ -183,6 +183,8 @@ def get_args():
     parser.add_argument('--save_model',type=int,default=0)
     parser.add_argument('--use_project_head', type=int, default=1)
     parser.add_argument('--server_momentum', type=float, default=0, help='the server momentum (FedAvgM)')
+    parser.add_argument('--use_transform_layer', type=int, default=0,
+                        help='Enable client-side transform layer before shared head (0/1)')
     args = parser.parse_args()
     return args
 
@@ -485,7 +487,8 @@ def train_net_few_shot_new(net_id, net, n_epoch, lr, args_optimizer, args, X_tra
                 net_para_ori=net.state_dict()
                 param_require_grad={}
                 for key, param in net_new.named_parameters():
-                    if key=='few_classify.weight' or key=='few_classify.bias' or 'transformer' in key:
+                    if (key=='few_classify.weight' or key=='few_classify.bias'
+                            or 'transformer' in key or 'transform_layer' in key):
                     #if key != 'module.all_classify.weight' and key != 'module.all_classify.bias':
                         param_require_grad[key]=param
 
@@ -790,7 +793,8 @@ if __name__ == '__main__':
                 else:
                     net_para = net.state_dict()
                     for key in net_para:
-                        if key!='few_classify.weight' and key!='few_classify.bias' and 'transformer' not in key:
+                        if (key!='few_classify.weight' and key!='few_classify.bias'
+                                and 'transformer' not in key and 'transform_layer' not in key):
                             net_para[key]=global_w[key]
                     net.load_state_dict(net_para)
 

--- a/model.py
+++ b/model.py
@@ -993,6 +993,7 @@ class LSTMAtt(nn.Module):
         # ebd = WORDEBD(args.finetune_ebd)
 
         self.args = args
+        self.use_transform_layer = bool(getattr(args, "use_transform_layer", 0))
         if args.dataset=='20newsgroup':
             self.max_text_len=500
         elif args.dataset=='fewrel':
@@ -1016,6 +1017,10 @@ class LSTMAtt(nn.Module):
         self.proj = nn.Linear(u * 2, da)
 
         self.ebd_dim = u * 2
+
+        if self.use_transform_layer:
+            self.transform_layer = nn.Linear(self.ebd_dim, self.ebd_dim, bias=False)
+            nn.init.eye_(self.transform_layer.weight)
 
         self.l1 = nn.Linear(self.ebd_dim, self.ebd_dim)
         self.l2 = nn.Linear(self.ebd_dim, out_dim)
@@ -1083,6 +1088,8 @@ class LSTMAtt(nn.Module):
 
         # aggregate
         ebd = torch.sum(ebd * alpha.unsqueeze(-1), dim=1)
+        if self.use_transform_layer:
+            ebd = self.transform_layer(ebd)
         #ebd = ebd.mean(1)
 
         #x=F.dropout(ebd, p=0.5,training=self.training)


### PR DESCRIPTION
## Summary
- add a `--use_transform_layer` flag to the text entrypoint for enabling the client-side transform layer
- extend the LSTMAtt model to optionally construct and apply an identity-initialized transform layer
- update FedAvg synchronization logic to keep client-specific transform layer parameters local

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd1867b7fc832aa2587f117edc7b8c