### PR TITLE
Enable cuDNN benchmarking when using CUDA

### DIFF
--- a/main_image.py
+++ b/main_image.py
@@ -979,6 +979,9 @@ if __name__ == '__main__':
     torch.manual_seed(seed)
     if torch.cuda.is_available():
         torch.cuda.manual_seed(seed)
+        torch.backends.cudnn.benchmark = True
+        # Note: toggling torch.backends.cudnn.deterministic after this point may
+        # lead to non-deterministic runs.
     random.seed(seed)
     #torch.backends.cudnn.deterministic = True
 


### PR DESCRIPTION
## Summary
- enable cuDNN benchmarking for CUDA runs right after seeding
- document the potential loss of determinism when toggling cudnn.deterministic later

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e48a79f194832a8312ef162bb42fee